### PR TITLE
chore: cleanup debuglog file logic

### DIFF
--- a/runtime/include/debuglog.h
+++ b/runtime/include/debuglog.h
@@ -4,6 +4,12 @@
 
 extern int32_t debuglog_file_descriptor;
 
+#ifdef LOG_TO_FILE
+#ifndef DEBUG
+#error LOG_TO_FILE is only valid if in DEBUG mode
+#endif /* DEBUG */
+#endif /* LOG_TO_FILE */
+
 /**
  * debuglog is a macro that behaves based on the macros DEBUG and LOG_TO_FILE
  * If DEBUG is not set, debuglog does nothing

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -135,16 +135,15 @@ void
 runtime_process_debug_log_behavior()
 {
 #ifdef LOG_TO_FILE
-	fclose(stdout);
-	fclose(stderr);
-	fclose(stdin);
 	debuglog_file_descriptor = open(RUNTIME_LOG_FILE, O_CREAT | O_TRUNC | O_WRONLY, S_IRWXU | S_IRWXG);
 	if (debuglog_file_descriptor < 0) {
-		perror("open");
+		perror("Error opening logfile\n");
 		exit(-1);
 	}
+	dup2(debuglog_file_descriptor, STDOUT_FILENO);
+	dup2(debuglog_file_descriptor, STDERR_FILENO);
 #else
-	debuglog_file_descriptor = 1;
+	debuglog_file_descriptor = STDOUT_FILENO;
 #endif /* LOG_TO_FILE */
 }
 #endif /* DEBUG */


### PR DESCRIPTION
Resolves #14 

Just validating that logging to a file works as expected, including slight validation of preprocessor defines and ensuring stderr is available to log if the debuglog file fails to open.