### PR TITLE
feat: Only dequeue request if actually earlier

### DIFF
--- a/runtime/include/global_request_scheduler.h
+++ b/runtime/include/global_request_scheduler.h
@@ -1,20 +1,25 @@
 #pragma once
 
+#include <stdint.h>
+
 #include "sandbox_request.h"
 
 /* Returns pointer back if successful, null otherwise */
 typedef struct sandbox_request *(*global_request_scheduler_add_fn_t)(void *);
 typedef int (*global_request_scheduler_remove_fn_t)(struct sandbox_request **);
+typedef int (*global_request_scheduler_remove_if_earlier_fn_t)(struct sandbox_request **, uint64_t);
 typedef uint64_t (*global_request_scheduler_peek_fn_t)(void);
 
 struct global_request_scheduler_config {
-	global_request_scheduler_add_fn_t    add_fn;
-	global_request_scheduler_remove_fn_t remove_fn;
-	global_request_scheduler_peek_fn_t   peek_fn;
+	global_request_scheduler_add_fn_t               add_fn;
+	global_request_scheduler_remove_fn_t            remove_fn;
+	global_request_scheduler_remove_if_earlier_fn_t remove_if_earlier_fn;
+	global_request_scheduler_peek_fn_t              peek_fn;
 };
 
 
 void                    global_request_scheduler_initialize(struct global_request_scheduler_config *config);
 struct sandbox_request *global_request_scheduler_add(struct sandbox_request *);
 int                     global_request_scheduler_remove(struct sandbox_request **);
+int                     global_request_scheduler_remove_if_earlier(struct sandbox_request **, uint64_t targed_deadline);
 uint64_t                global_request_scheduler_peek();

--- a/runtime/include/priority_queue.h
+++ b/runtime/include/priority_queue.h
@@ -37,10 +37,11 @@ priority_queue_is_empty(struct priority_queue *self)
 	return self->highest_priority == ULONG_MAX;
 }
 
-void     priority_queue_initialize(struct priority_queue *self, priority_queue_get_priority_fn_t get_priority_fn);
-int      priority_queue_enqueue(struct priority_queue *self, void *value);
-int      priority_queue_dequeue(struct priority_queue *self, void **dequeued_element);
-int      priority_queue_length(struct priority_queue *self);
+void priority_queue_initialize(struct priority_queue *self, priority_queue_get_priority_fn_t get_priority_fn);
+int  priority_queue_enqueue(struct priority_queue *self, void *value);
+int  priority_queue_dequeue(struct priority_queue *self, void **dequeued_element);
+int  priority_queue_dequeue_if_earlier(struct priority_queue *self, void **dequeued_element, uint64_t target_deadline);
+int  priority_queue_length(struct priority_queue *self);
 uint64_t priority_queue_peek(struct priority_queue *self);
 int      priority_queue_delete(struct priority_queue *self, void *value);
 int      priority_queue_top(struct priority_queue *self, void **dequeued_element);

--- a/runtime/src/global_request_scheduler.c
+++ b/runtime/src/global_request_scheduler.c
@@ -62,6 +62,20 @@ global_request_scheduler_remove(struct sandbox_request **removed_sandbox)
 }
 
 /**
+ * Removes a sandbox request according to the scheduling policy of the variant
+ * @param removed_sandbox where to write the adddress of the removed sandbox
+ * @param target_deadline the deadline that must be validated before dequeuing
+ * @returns 0 if successfully returned a sandbox request, -ENOENT if empty or if no element meets target_deadline,
+ * -EAGAIN if atomic operation unsuccessful
+ */
+int
+global_request_scheduler_remove_if_earlier(struct sandbox_request **removed_sandbox, uint64_t target_deadline)
+{
+	assert(removed_sandbox != NULL);
+	return global_request_scheduler.remove_if_earlier_fn(removed_sandbox, target_deadline);
+}
+
+/**
  * Peeks at the priority of the highest priority sandbox request
  * @returns highest priority
  */

--- a/runtime/src/global_request_scheduler_deque.c
+++ b/runtime/src/global_request_scheduler_deque.c
@@ -36,6 +36,14 @@ global_request_scheduler_deque_remove(struct sandbox_request **removed_sandbox_r
 	return deque_steal_sandbox(global_request_scheduler_deque, removed_sandbox_request);
 }
 
+static int
+global_request_scheduler_deque_remove_if_earlier(struct sandbox_request **removed_sandbox_request,
+                                                 uint64_t                 target_deadline)
+{
+	panic("Deque variant does not support this call\n");
+	return -1;
+}
+
 void
 global_request_scheduler_deque_initialize()
 {
@@ -46,8 +54,11 @@ global_request_scheduler_deque_initialize()
 	deque_init_sandbox(global_request_scheduler_deque, RUNTIME_MAX_SANDBOX_REQUEST_COUNT);
 
 	/* Register Function Pointers for Abstract Scheduling API */
-	struct global_request_scheduler_config config = { .add_fn    = global_request_scheduler_deque_add,
-		                                          .remove_fn = global_request_scheduler_deque_remove };
+	struct global_request_scheduler_config config = {
+		.add_fn               = global_request_scheduler_deque_add,
+		.remove_fn            = global_request_scheduler_deque_remove,
+		.remove_if_earlier_fn = global_request_scheduler_deque_remove_if_earlier
+	};
 
 	global_request_scheduler_initialize(&config);
 }


### PR DESCRIPTION
The main goal of all is to provide an interface that allows the caller to specify a `target_deadline` (the deadline of what the worker is currently running) during a request dequeue so that the following check can occur after taking the lock.

`self->highest_priority >= target_deadline`

If the above is true the function releases the lock and returns -ENOENT to the worker thread, which allows it to immediately exit the SIGALRM handler and resume what it was already working on.

The diff is a bit noisy because it involves two different polymorphic interfaces.