### PR TITLE
chore: Ignore submodules when using clang-format

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -25,6 +25,6 @@ if ((major < required_major)) || ((minor < required_minor)) || ((patch < require
   exit 1
 fi
 
-find ./runtime -type f -path "./*.[ch]" |                             # Match all *.c and *.h files in ./runtime
-  grep --invert-match -E "./runtime/jsmn/*|./runtime/http-parser/*" | # Excluding those in the jsmn or http-parser submodules
-  xargs clang-format -i                                               # And format them with clang-format
+find ./runtime -type f -path "./*.[ch]" |                                                                                                               # Match all *.c and *.h files in ./runtime
+  grep --invert-match -E "./runtime/thirdparty/*|./runtime/tests/gocr/*|./runtime/tests/TinyEKF/*|./runtime/tests/CMSIS_5_NN/*|./runtime/tests/sod/*" | # Excluding those in the jsmn or http-parser submodules
+  xargs clang-format -i                                                                                                                                 # And format them with clang-format

--- a/runtime/include/current_sandbox.h
+++ b/runtime/include/current_sandbox.h
@@ -2,9 +2,9 @@
 
 #include "sandbox.h"
 
-void                 current_sandbox_close_file_descriptor(int io_handle_index);
-struct sandbox *     current_sandbox_get(void);
-int                  current_sandbox_get_file_descriptor(int io_handle_index);
-int                  current_sandbox_initialize_io_handle(void);
-void                 current_sandbox_set(struct sandbox *sandbox);
-int                  current_sandbox_set_file_descriptor(int io_handle_index, int file_descriptor);
+void            current_sandbox_close_file_descriptor(int io_handle_index);
+struct sandbox *current_sandbox_get(void);
+int             current_sandbox_get_file_descriptor(int io_handle_index);
+int             current_sandbox_initialize_io_handle(void);
+void            current_sandbox_set(struct sandbox *sandbox);
+int             current_sandbox_set_file_descriptor(int io_handle_index, int file_descriptor);

--- a/runtime/tools/udpclient/udpclient.c
+++ b/runtime/tools/udpclient/udpclient.c
@@ -42,8 +42,8 @@ send_fn(void *d)
 {
 	struct request *r = (struct request *)d;
 
-	char               resp[STR_MAX] = { 0 };
-	int                file_descriptor            = -1;
+	char               resp[STR_MAX]   = { 0 };
+	int                file_descriptor = -1;
 	struct sockaddr_in sa;
 
 	sa.sin_family      = AF_INET;
@@ -54,7 +54,8 @@ send_fn(void *d)
 		return NULL;
 	}
 
-	if (sendto(file_descriptor, r->msg, strlen(r->msg), 0, (struct sockaddr *)&sa, sizeof(sa)) < 0 && errno != EINTR) {
+	if (sendto(file_descriptor, r->msg, strlen(r->msg), 0, (struct sockaddr *)&sa, sizeof(sa)) < 0
+	    && errno != EINTR) {
 		perror("sendto");
 		return NULL;
 	}


### PR DESCRIPTION
Resolves #59 

Please check the following:
1. That your clang-format installation is picking up our project configuration. Running `./format.sh` should not trigger changes beyond what I have added to this PR
2. That your code editor is configured to run clang-format on save, such that it does not conflict with the formatting performed by this script
3. That running `./format.sh` does not format code in submodules. Each repo should be responsible for handling this locally.