### PR TITLE
fix: Ensure workers init before softints

### DIFF
--- a/runtime/src/software_interrupt.c
+++ b/runtime/src/software_interrupt.c
@@ -57,6 +57,9 @@ sigalrm_propagate_workers(siginfo_t *signal_info)
 		for (int i = 0; i < runtime_worker_threads_count; i++) {
 			if (pthread_self() == runtime_worker_threads[i]) continue;
 
+			/* All threads should have been initialized */
+			assert(runtime_worker_threads[i] != 0);
+
 			pthread_kill(runtime_worker_threads[i], SIGALRM);
 		}
 	} else {


### PR DESCRIPTION
Determined that there is a race between worker and listener thread initialization, such that signals might be enabled before all worker threads are created. PR refactored startup logic such that the listener thread only starts after all worker threads are up.