### PR TITLE
chore: Attempt to update to llvm11

### DIFF
--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -14,32 +14,24 @@ RUN apt-get install -y --no-install-recommends \
   binutils-dev \
   cmake \
   git \
-  libc++-dev \
   libtinfo5 \
   libtool \
   pkg-config
 
-# LLVM Tools
-RUN apt-get install -y --no-install-recommends \
-  clang-11 \
-  clang-format-11 \
-  clang-tools-11 \
-  libclang-11-dev \
-  libclang-common-11-dev \
-  libc++abi-dev \
-  lld-11 \
-  llvm-11 \
-  llvm-11-dev
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 100
-RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 100
-RUN update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-11 100
-RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 100
-
-# Needed to install from http endpoints via curl
+# Needed to install from http endpoints via curl or wget
 RUN apt-get install -y --no-install-recommends \
   curl \
   ca-certificates \
-  libssl-dev
+  libssl-dev \
+  lsb-release \
+  gpg-agent \
+  software-properties-common \
+  wget
+
+# LLVM Tools
+ENV LLVM_VERSION=8
+ADD install_llvm.sh /sledge/install_llvm.sh
+RUN ./sledge/install_llvm.sh $LLVM_VERSION
 
 # Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable --component rustfmt --target wasm32-wasi -y
@@ -58,8 +50,7 @@ RUN apt-get install -y --no-install-recommends \
   imagemagick \
   netpbm \
   pango1.0-tools \
-  wamerican \
-  wget
+  wamerican
 
 # Interactive Tools
 RUN apt-get install -y --no-install-recommends \

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -21,16 +21,19 @@ RUN apt-get install -y --no-install-recommends \
 
 # LLVM Tools
 RUN apt-get install -y --no-install-recommends \
-  clang-8 \
-  clang-tools-8 \
-  llvm-8 \
-  llvm-8-dev \
+  clang-11 \
+  clang-format-11 \
+  clang-tools-11 \
+  libclang-11-dev \
+  libclang-common-11-dev \
   libc++abi-dev \
-  lld-8 \
-  libclang-8-dev \
-  libclang-common-8-dev
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100
-RUN update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-8 100
+  lld-11 \
+  llvm-11 \
+  llvm-11-dev
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 100
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 100
+RUN update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-11 100
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 100
 
 # Needed to install from http endpoints via curl
 RUN apt-get install -y --no-install-recommends \

--- a/install_llvm.sh
+++ b/install_llvm.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Installs LLVM tooling, delegating the to the LLVM script as much as possible
+# We need to shim support for LLVM 8 because the LLVM script only supports 9-12
+
+LLVM_VERSION=$1
+
+echo "Installing LLVM $LLVM_VERSION"
+
+# Script Installs clang, lldb, lld, and clangd
+if [[ "$LLVM_VERSION" -gt 8 ]]; then
+  curl --proto '=https' --tlsv1.2 -sSf https://apt.llvm.org/llvm.sh | bash -s -- "$LLVM_VERSION"
+else
+  apt-get install -y --no-install-recommends \
+    "clang-$LLVM_VERSION" \
+    "lldb-$LLVM_VERSION" \
+    "lld-$LLVM_VERSION" \
+    "clangd-$LLVM_VERSION"
+fi
+
+apt-get install -y --no-install-recommends \
+  "libc++-$LLVM_VERSION-dev" \
+  "libc++abi-$LLVM_VERSION-dev" \
+  "libc++1-$LLVM_VERSION" \
+  "clang-format-$LLVM_VERSION"
+
+update-alternatives --install /usr/bin/clang clang "/usr/bin/clang-$LLVM_VERSION" 100
+update-alternatives --install /usr/bin/clang++ clang++ "/usr/bin/clang++-$LLVM_VERSION" 100
+update-alternatives --install /usr/bin/llvm-config llvm-config "/usr/bin/llvm-config-$LLVM_VERSION" 100
+update-alternatives --install /usr/bin/clang-format clang-format "/usr/bin/clang-format-$LLVM_VERSION" 100


### PR DESCRIPTION
awsm has a transitive dependency on llvm8:

```
1 warning generated.
awsm --inline-constant-globals --runtime-globals gocr.wasm -o gocr.bc
awsm: error while loading shared libraries: libLLVM-8.so.1: cannot open shared object file: No such file or directory
```

The script can now install different versions by setting LLVM_VERSION. This is pinned to 8 for now.