### PR TITLE
A simple solution to fix compiling permission error of issue #242

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq ($(ARCH),x86_64)
 	cd ./awsm/wasmception && wget ${WASMCEPTION_URL} -O wasmception.tar.gz && tar xvfz wasmception.tar.gz && rm wasmception.tar.gz
 endif
 	test -f ./${COMPILER}/wasmception/dist/bin/clang || make -C ${COMPILER}/wasmception
-	@cd ${COMPILER} && cargo build --release && cd ${ROOT}
+	@cd ${COMPILER} && RUSTUP_TOOLCHAIN=stable cargo build --release && cd ${ROOT}
 
 # Sanity check that the aWsm compiler built and is in our PATH
 .PHONY: build-validate

--- a/devenv.sh
+++ b/devenv.sh
@@ -103,7 +103,7 @@ envsetup() {
 
 	# Execute the make install command on the sledge-dev image to build the project
 	echo "Building ${SYS_NAME}"
-	docker exec \
+	docker exec -u 0 \
 		--tty \
 		--workdir "${HOST_SYS_MOUNT}" \
 		${SYS_DOC_DEVNAME} make install
@@ -144,7 +144,7 @@ envrun() {
 	fi
 
 	echo "Running shell"
-	docker exec --tty --interactive --workdir "${HOST_SYS_MOUNT}" ${SYS_DOC_NAME} /bin/bash
+	docker exec -u 0 --tty --interactive --workdir "${HOST_SYS_MOUNT}" ${SYS_DOC_NAME} /bin/bash
 }
 
 # Stops and removes the sledge "runtime" container


### PR DESCRIPTION
This is a simple solution to fix the compiling permission error related to issue #242 . The partial reason to cause #242 is the container tries to write some files to the host disk during the compilation but it does not have the root permission. This solution is to give the container a root permission to write files to the host disk. Since the solution doesn't consider the security issue if we give it the root permission, it is a simple solution, not a perfect solution. But it could help anyone who are blocked by this compiling  error. 