### PR TITLE
feat: More detailed HTTP response headers

### DIFF
--- a/runtime/include/http.h
+++ b/runtime/include/http.h
@@ -6,12 +6,29 @@
 #define HTTP_MAX_HEADER_LENGTH       32
 #define HTTP_MAX_HEADER_VALUE_LENGTH 64
 
-#define HTTP_RESPONSE_400_BAD_REQUEST         "HTTP/1.1 400 Bad Request\r\n\r\n"
-#define HTTP_RESPONSE_413_PAYLOAD_TOO_LARGE   "HTTP/1.1 413 Payload Too Large\r\n\r\n"
-#define HTTP_RESPONSE_503_SERVICE_UNAVAILABLE "HTTP/1.1 503 Service Unavailable\r\n\r\n"
+#define HTTP_RESPONSE_400_BAD_REQUEST  \
+	"HTTP/1.1 400 Bad Request\r\n" \
+	"Server: SLEdge\r\n"           \
+	"Connection: close\r\n"        \
+	"\r\n"
+
+
+#define HTTP_RESPONSE_413_PAYLOAD_TOO_LARGE  \
+	"HTTP/1.1 413 Payload Too Large\r\n" \
+	"Server: SLEdge\r\n"                 \
+	"Connection: close\r\n"              \
+	"\r\n"
+
+#define HTTP_RESPONSE_503_SERVICE_UNAVAILABLE  \
+	"HTTP/1.1 503 Service Unavailable\r\n" \
+	"Server: SLEdge\r\n"                   \
+	"Connection: close\r\n"                \
+	"\r\n"
 
 #define HTTP_RESPONSE_200_TEMPLATE \
 	"HTTP/1.1 200 OK\r\n"      \
+	"Server: SLEdge\r\n"       \
+	"Connection: close\r\n"    \
 	"Content-Type: %s\r\n"     \
 	"Content-Length: %s\r\n"   \
 	"\r\n"


### PR DESCRIPTION
In the past, we've had issues with hey if we didn't manually set the `-disable-keepalive` flag. After a bit of reading, it seems that the HTTP spec allows a server to set "Connection: close\r\n". If the request includes a keep-alive header, this in effect is how a server can tell the client that it did not / was not able to we did not actually keep the request alive. 

While I was in here, I added the Server header for a bit of swagger.

For example, `echo "40" | http :10040` generates the following:

```http
HTTP/1.1 200 OK
Connection: close
Content-Length: 10
Content-Type: text/plain
Server: SLEdge

102334155
```