### PR TITLE
303 missing abi symbols

### DIFF
--- a/libsledge/README.md
+++ b/libsledge/README.md
@@ -69,19 +69,20 @@ The ABI includes the
 | i64.trunc_f32_u | `u64_trunc_f32`                          | `UINT64_MAX`, `stderr`, `fprintf`             | `sledge_abi__wasm_trap_raise`, `WASM_TRAP_ILLEGAL_ARITHMETIC_OPERATION` |
 | i64.trunc_f64_s | `i64_trunc_f64`                          | `INT64_MIN`, `INT64_MAX`, `stderr`, `fprintf` | `sledge_abi__wasm_trap_raise`, `WASM_TRAP_ILLEGAL_ARITHMETIC_OPERATION` |
 | i64.trunc_f64_u | `u64_trunc_f64`                          | `UINT64_MAX`, `stderr`, `fprintf`             | `sledge_abi__wasm_trap_raise`, `WASM_TRAP_ILLEGAL_ARITHMETIC_OPERATION` |
-| f32.ceil        | `f32_ceil`                               | **NOT SUPPORTED**                             | **NOT SUPPORTED**                                                       |
-| f32.copysign    | `f32_copysign`                           | **NOT SUPPORTED**                             | **NOT SUPPORTED**                                                       |
-| f32.floor       | `f32_floor`                              | `floor`                                       | None                                                                    |
+| f32.ceil        | `f32_ceil`                               | `ceilf`                                       | `ceilf`                                                                 |
+| f32.copysign    | `f32_copysign`                           | `copysignf`                                   | `copysignf`                                                             |
+| f32.floor       | `f32_floor`                              | `floorf`                                      | `floorf`                                                                |
 | f32.max         | `f32_max`                                | None                                          | None                                                                    |
 | f32.min         | `f32_min`                                | None                                          | None                                                                    |
-| f32.nearest     | `f32_nearest`                            | **NOT SUPPORTED**                             | **NOT SUPPORTED**                                                       |
-| f32.trunc       | `f32_trunc_f32`                          | `trunc`                                       | None                                                                    |
-| f64.ceil        | `f64_ceil`                               | **NOT SUPPORTED**                             | **NOT SUPPORTED**                                                       |
-| f64.floor       | `f64_floor`                              | `floor`                                       | None                                                                    |
+| f32.nearest     | `f32_nearest`                            | `nearbyintf`                                  | `nearbyintf`                                                            |
+| f32.trunc       | `f32_trunc_f32`                          | `truncf`                                      | `truncf`                                                                |
+| f64.ceil        | `f64_ceil`                               | `ceil`                                        | `ceil`                                                                  |
+| f64.copysign    | `f64_copysign`                           | `copysign`                                    | `copysign`                                                              |
+| f64.floor       | `f64_floor`                              | `floor`                                       | `floor`                                                                 |
 | f64.max         | `f64_max`                                | None                                          | None                                                                    |
 | f64.min         | `f64_min`                                | None                                          | None                                                                    |
-| f64.nearest     | `f64_nearest`                            | **NOT SUPPORTED**                             | **NOT SUPPORTED**                                                       |
-| f64.trunc       | `f64_trunc_f64`                          | **NOT SUPPORTED**                             | **NOT SUPPORTED**                                                       |
+| f64.nearest     | `f64_nearest`                            | `nearbyint`                                   | `nearbyint`                                                             |
+| f64.trunc       | `f64_trunc_f64`                          | `trunc`                                       | `trunc`                                                                 |
 
 ### [Memory Instructions](https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions)
 

--- a/libsledge/src/numeric_instructions.c
+++ b/libsledge/src/numeric_instructions.c
@@ -166,7 +166,6 @@ i64_trunc_f64(double f)
 	return (int64_t)f;
 }
 
-// Float => Float truncation functions
 INLINE float
 f32_trunc_f32(float f)
 {
@@ -209,7 +208,6 @@ f32_nearest(float a)
 	return nearbyintf(a);
 }
 
-// Float => Float truncation functions
 INLINE double
 f64_trunc_f64(double f)
 {
@@ -240,7 +238,6 @@ f64_ceil(double a)
 	return ceil(a);
 }
 
-// TODO: Is this missing in aWsm? f64.copysign
 INLINE double
 f64_copysign(double a, double b)
 {

--- a/libsledge/src/numeric_instructions.c
+++ b/libsledge/src/numeric_instructions.c
@@ -170,7 +170,7 @@ i64_trunc_f64(double f)
 INLINE float
 f32_trunc_f32(float f)
 {
-	return trunc(f);
+	return truncf(f);
 }
 
 INLINE float
@@ -188,7 +188,32 @@ f32_max(float a, float b)
 INLINE float
 f32_floor(float a)
 {
-	return floor(a);
+	return floorf(a);
+}
+
+INLINE float
+f32_ceil(float a)
+{
+	return ceilf(a);
+}
+
+INLINE float
+f32_copysign(float a, float b)
+{
+	return copysignf(a, b);
+}
+
+INLINE float
+f32_nearest(float a)
+{
+	return nearbyintf(a);
+}
+
+// Float => Float truncation functions
+INLINE double
+f64_trunc_f64(double f)
+{
+	return trunc(f);
 }
 
 INLINE double
@@ -207,4 +232,23 @@ INLINE double
 f64_floor(double a)
 {
 	return floor(a);
+}
+
+INLINE double
+f64_ceil(double a)
+{
+	return ceil(a);
+}
+
+// TODO: Is this missing in aWsm? f64.copysign
+INLINE double
+f64_copysign(double a, double b)
+{
+	return copysign(a, b);
+}
+
+INLINE double
+f64_nearest(double a)
+{
+	return nearbyint(a);
 }


### PR DESCRIPTION
Resolves #303 

Adds missing backing functions for instructions that aWsm supports.