### PR TITLE
feat: Dynamically size runtime globals

### DIFF
--- a/libsledge/README.md
+++ b/libsledge/README.md
@@ -144,6 +144,7 @@ The path to the JSON file is passed to `module_alloc_from_json`, which uses the 
 `module.abi.entrypoint` -> `SLEDGE_ABI__ENTRYPOINT` -> `wasmf__start`
 `module.abi.starting_pages` -> `SLEDGE_ABI__STARTING_PAGES` -> `starting_pages`
 `module.abi.max_pages` -> `SLEDGE_ABI__MAX_PAGES` -> `max_pages`
+`module.abi.globals_len` -> `SLEDGE_ABI__GLOBALS_LEN` -> `globals_len`
 
 `module init` then calls `module.abi.initialize_table`, which populates the indirect function table with the actual functions. This is performed once during module initialization because this table does not actually vary between instances of a module.
 

--- a/libsledge/include/sledge_abi.h
+++ b/libsledge/include/sledge_abi.h
@@ -92,6 +92,9 @@ typedef uint32_t (*sledge_abi__wasm_memory_starting_pages_fn_t)(void);
 typedef uint32_t (*sledge_abi__wasm_memory_max_pages_fn_t)(void);
 #define SLEDGE_ABI__MAX_PAGES "sledge_abi__wasm_memory_max_pages"
 
+typedef uint32_t (*sledge_abi__wasm_memory_globals_len_fn_t)(void);
+#define SLEDGE_ABI__GLOBALS_LEN "sledge_abi__wasm_globals_len"
+
 typedef uint32_t __wasi_clockid_t;
 typedef uint64_t __wasi_dircookie_t;
 typedef uint32_t __wasi_exitcode_t;

--- a/libsledge/src/instantiation.c
+++ b/libsledge/src/instantiation.c
@@ -20,6 +20,7 @@ extern void     populate_table(void);
 extern int32_t  wasmf__start(void);
 extern uint32_t starting_pages;
 extern uint32_t max_pages;
+extern uint32_t globals_len;
 
 WEAK void populate_globals(){};
 
@@ -57,4 +58,10 @@ EXPORT uint32_t
 sledge_abi__wasm_memory_max_pages(void)
 {
 	return max_pages;
+}
+
+EXPORT uint32_t
+sledge_abi__wasm_globals_len(void)
+{
+	return globals_len;
 }

--- a/runtime/include/sledge_abi_symbols.h
+++ b/runtime/include/sledge_abi_symbols.h
@@ -16,6 +16,7 @@ struct sledge_abi_symbols {
 	sledge_abi__entrypoint_fn_t   entrypoint;
 	uint32_t                      starting_pages;
 	uint32_t                      max_pages;
+	uint32_t                      globals_len;
 };
 
 /* Initializes the ABI object using the *.so file at path */
@@ -77,6 +78,14 @@ sledge_abi_symbols_init(struct sledge_abi_symbols *abi, char *path)
 		goto dl_error;
 	}
 	abi->max_pages = get_max_pages();
+
+	sledge_abi__wasm_memory_globals_len_fn_t get_globals_len = dlsym(abi->handle, SLEDGE_ABI__GLOBALS_LEN);
+	if (get_max_pages == NULL) {
+		fprintf(stderr, "Failed to resolve symbol %s in %s with error: %s\n", SLEDGE_ABI__GLOBALS_LEN, path,
+		        dlerror());
+		goto dl_error;
+	}
+	abi->globals_len = get_globals_len();
 
 done:
 	return rc;

--- a/runtime/include/sledge_abi_symbols.h
+++ b/runtime/include/sledge_abi_symbols.h
@@ -80,7 +80,7 @@ sledge_abi_symbols_init(struct sledge_abi_symbols *abi, char *path)
 	abi->max_pages = get_max_pages();
 
 	sledge_abi__wasm_memory_globals_len_fn_t get_globals_len = dlsym(abi->handle, SLEDGE_ABI__GLOBALS_LEN);
-	if (get_max_pages == NULL) {
+	if (get_globals_len == NULL) {
 		fprintf(stderr, "Failed to resolve symbol %s in %s with error: %s\n", SLEDGE_ABI__GLOBALS_LEN, path,
 		        dlerror());
 		goto dl_error;

--- a/runtime/src/sandbox.c
+++ b/runtime/src/sandbox.c
@@ -59,7 +59,7 @@ sandbox_allocate_globals(struct sandbox *sandbox)
 	assert(sandbox);
 	assert(sandbox->module);
 
-	return wasm_globals_init(&sandbox->globals, 50);
+	return wasm_globals_init(&sandbox->globals, sandbox->module->abi.globals_len);
 }
 
 static inline void


### PR DESCRIPTION
- Modified `aWsm` to write the global `globals_len` containing the number of `(global)` instructions in the source wasm module
- Extended this through the SLEdge ABI interfaces
- Uses the value to size the globals vector during sandbox initialization.