### PR TITLE
fix: Remove memory size from perf log

### DIFF
--- a/runtime/include/sandbox_perf_log.h
+++ b/runtime/include/sandbox_perf_log.h
@@ -36,7 +36,7 @@ sandbox_perf_log_print_entry(struct sandbox *sandbox)
 	 * becomes more intelligent, then peak linear memory size needs to be tracked
 	 * seperately from current linear memory size.
 	 */
-	fprintf(sandbox_perf_log, "%lu,%s,%d,%s,%lu,%lu,%lu,,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%u,%lu\n",
+	fprintf(sandbox_perf_log, "%lu,%s,%d,%s,%lu,%lu,%lu,,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%u\n",
 	        sandbox->id, sandbox->module->name, sandbox->module->port, sandbox_state_stringify(sandbox->state),
 	        sandbox->module->relative_deadline, sandbox->total_time, queued_duration,
 	        sandbox->duration_of_state[SANDBOX_UNINITIALIZED], sandbox->duration_of_state[SANDBOX_ALLOCATED],
@@ -45,7 +45,7 @@ sandbox_perf_log_print_entry(struct sandbox *sandbox)
 	        sandbox->duration_of_state[SANDBOX_RUNNING_SYS], sandbox->duration_of_state[SANDBOX_RUNNING_USER],
 	        sandbox->duration_of_state[SANDBOX_ASLEEP], sandbox->duration_of_state[SANDBOX_RETURNED],
 	        sandbox->duration_of_state[SANDBOX_COMPLETE], sandbox->duration_of_state[SANDBOX_ERROR],
-	        runtime_processor_speed_MHz, sandbox->memory->abi.size);
+	        runtime_processor_speed_MHz);
 }
 
 static inline void


### PR DESCRIPTION
The memory member is now set to null by this point due to the object pool, triggering a segfault if perf log is enabled. This removes memory size from the perf log to fix this.