### PR TITLE
Solve partial builing and running issues for ARM machines

### DIFF
--- a/runtime/include/sandbox_set_as_initialized.h
+++ b/runtime/include/sandbox_set_as_initialized.h
@@ -34,7 +34,7 @@ sandbox_set_as_initialized(struct sandbox *sandbox, sandbox_state_t last_state)
 	}
 
 	/* State Change Bookkeeping */
-	assert(now > sandbox->timestamp_of.last_state_change);
+	assert(now >= sandbox->timestamp_of.last_state_change);
 	sandbox->duration_of_state[last_state] += (now - sandbox->timestamp_of.last_state_change);
 	sandbox->timestamp_of.last_state_change = now;
 	sandbox_state_history_append(&sandbox->state_history, SANDBOX_INITIALIZED);

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -102,6 +102,7 @@ runtime_get_processor_speed_MHz(void)
 {
 	uint32_t return_value;
 
+	/* TODO: Find another way to get the cpu speed for ARM machines, this only works for Intel machines */
 	FILE *cmd = popen("grep '^cpu MHz' /proc/cpuinfo | head -n 1 | awk '{print $4}'", "r");
 	if (unlikely(cmd == NULL)) goto err;
 


### PR DESCRIPTION
Resolves #169 

This PR includes the following changes:

- Modified the assembly code for ARM to fix the assert failure of sandbox state
-  `assert(now > sandbox->timestamp_of.last_state_change)` in sandbox_set_as_initialized.h failed in ARM machine because `now` is equal to `sandbox->timestamp_of.last_state_change`, so modity the assert to `assert(now >= sandbox->timestamp_of.last_state_change)`
- Add TODO of finding another way to get CPU speed for ARM machines in main.c 