### PR TITLE
chore: Remove zombie macros

### DIFF
--- a/runtime/include/wasm_types.h
+++ b/runtime/include/wasm_types.h
@@ -1,8 +1,4 @@
 #pragma once
 
-#include <stdint.h>
-
-#define WASM_PAGE_SIZE            (1024 * 64) /* 64KB */
-#define WASM_MEMORY_PAGES_INITIAL (1 << 8)    /* 256 Pages ~16MB */
-#define WASM_MEMORY_PAGES_MAX     (1 << 16)   /* 32,768 Pages ~4GB */
-#define WASM_STACK_SIZE           (1 << 19)   /* 512KB */
+#define WASM_PAGE_SIZE  (1024 * 64) /* 64KB */
+#define WASM_STACK_SIZE (1 << 19)   /* 512KB */


### PR DESCRIPTION
Resolves #268 

The feature to read linear memory symbols was already implemented. This just cleans up zombie symbols from when these values were static.