### PR TITLE
Json refactor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -111,7 +111,8 @@
 		"wasm_memory.h": "c",
 		"sledge_abi.h": "c",
 		"vec.h": "c",
-		"module_database.h": "c"
+		"module_database.h": "c",
+		"perf_window_t.h": "c"
 	},
 	"files.exclude": {
 		"**/.git": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -110,7 +110,8 @@
 		"current_wasm_module_instance.h": "c",
 		"wasm_memory.h": "c",
 		"sledge_abi.h": "c",
-		"vec.h": "c"
+		"vec.h": "c",
+		"module_database.h": "c"
 	},
 	"files.exclude": {
 		"**/.git": true,

--- a/runtime/include/admissions_info.h
+++ b/runtime/include/admissions_info.h
@@ -4,12 +4,12 @@
 
 struct admissions_info {
 	struct perf_window perf_window;
-	int                percentile;        /* 50 - 99 */
+	uint8_t            percentile;        /* 50 - 99 */
 	int                control_index;     /* Precomputed Lookup index when perf_window is full */
 	uint64_t           estimate;          /* cycles */
 	uint64_t           relative_deadline; /* Relative deadline in cycles. This is duplicated state */
 };
 
-void admissions_info_initialize(struct admissions_info *admissions_info, int percentile, uint64_t expected_execution,
-                                uint64_t relative_deadline);
+void admissions_info_initialize(struct admissions_info *admissions_info, uint8_t percentile,
+                                uint64_t expected_execution, uint64_t relative_deadline);
 void admissions_info_update(struct admissions_info *admissions_info, uint64_t execution_duration);

--- a/runtime/include/json.h
+++ b/runtime/include/json.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <jsmn.h>
+
+#include "runtime.h"
+#include "http.h"
+#include "module.h"
+
+static const int JSON_MAX_ELEMENT_COUNT = 16;
+static const int JSON_MAX_ELEMENT_SIZE  = 1024;
+
+struct module_config {
+	char    *name;
+	char    *path;
+	int      port;
+	uint32_t expected_execution_us;
+	int      admissions_percentile;
+	uint32_t relative_deadline_us;
+	int32_t  http_req_size;
+	int32_t  http_resp_size;
+	char    *http_resp_content_type;
+};
+
+static void
+print_module_config(struct module_config *config)
+{
+	printf("Name: %s\n", config->name);
+	printf("Path: %s\n", config->path);
+	printf("Port: %d\n", config->port);
+	printf("expected_execution_us: %u\n", config->expected_execution_us);
+	printf("admissions_percentile: %d\n", config->admissions_percentile);
+	printf("relative_deadline_us: %u\n", config->relative_deadline_us);
+	printf("http_req_size: %u\n", config->http_req_size);
+	printf("http_resp_size: %u\n", config->http_resp_size);
+	printf("http_resp_content_type: %s\n", config->http_resp_content_type);
+}
+
+static inline char *
+jsmn_type(jsmntype_t type)
+{
+	switch (type) {
+	case JSMN_UNDEFINED:
+		return "Undefined";
+	case JSMN_OBJECT:
+		return "Object";
+	case JSMN_ARRAY:
+		return "Array";
+	case JSMN_STRING:
+		return "String";
+	case JSMN_PRIMITIVE:
+		return "Primitive";
+	default:
+		return "Invalid";
+	}
+}
+
+/**
+ * Parses a JSON file into an array of module configs
+ * @param file_name The path of the JSON file
+ * @return module_config_vec_len on success. -1 on Error
+ */
+static inline int
+parse_json(const char *json_buf, ssize_t json_buf_size, struct module_config **module_config_vec)
+{
+	assert(json_buf != NULL);
+	assert(json_buf_size > 0);
+	assert(module_config_vec != NULL);
+
+	jsmntok_t tokens[JSON_MAX_ELEMENT_SIZE * JSON_MAX_ELEMENT_COUNT];
+	int       module_config_vec_len = 0;
+
+
+	/* Initialize the Jasmine Parser and an array to hold the tokens */
+	jsmn_parser module_parser;
+	jsmn_init(&module_parser);
+
+	/* Use Jasmine to parse the JSON */
+	int total_tokens = jsmn_parse(&module_parser, json_buf, json_buf_size, tokens,
+	                              sizeof(tokens) / sizeof(tokens[0]));
+	if (total_tokens < 0) {
+		if (total_tokens == JSMN_ERROR_INVAL) {
+			fprintf(stderr, "Error parsing %s: bad token, JSON string is corrupted\n", json_buf);
+		} else if (total_tokens == JSMN_ERROR_PART) {
+			fprintf(stderr, "Error parsing %s: JSON string is too short, expecting more JSON data\n",
+			        json_buf);
+		} else if (total_tokens == JSMN_ERROR_NOMEM) {
+			/*
+			 * According to the README at https://github.com/zserge/jsmn, this is a potentially recoverable
+			 * error. More tokens can be allocated and jsmn_parse can be re-invoked.
+			 */
+			fprintf(stderr, "Error parsing %s: Not enough tokens, JSON string is too large\n", json_buf);
+		}
+		goto err;
+	}
+
+	if (tokens[0].type != JSMN_ARRAY) {
+		fprintf(stderr, "Outermost Config should be a JSON array\n");
+		goto err;
+	}
+
+	module_config_vec_len = tokens[0].size;
+	if (module_config_vec_len == 0) {
+		fprintf(stderr, "Config is an empty JSON array\n");
+		goto err;
+	}
+
+	*module_config_vec = (struct module_config *)calloc(module_config_vec_len, sizeof(struct module_config));
+	int module_idx     = -1;
+	int module_fields_remaining = 0;
+
+	for (int i = 1; i < total_tokens; i++) {
+		char key[32]  = { 0 };
+		char val[256] = { 0 };
+
+		if (tokens[i].type == JSMN_OBJECT) {
+			assert(module_fields_remaining == 0);
+			module_fields_remaining = tokens[i].size;
+			module_idx++;
+		} else {
+			/* Inside Object */
+			assert(tokens[i].type == JSMN_STRING);
+			sprintf(key, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
+			if (strcmp(key, "name") == 0) {
+				/* Should always have a value */
+				assert(tokens[i].size == 1);
+				i++;
+				assert(tokens[i].type == JSMN_STRING);
+				assert(tokens[i].end - tokens[i].start > 0);
+				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
+				(*module_config_vec)[module_idx].name = strndup(val, tokens[i].end - tokens[i].start);
+			} else if (strcmp(key, "path") == 0) {
+				assert(tokens[i].size == 1);
+				i++;
+				assert(tokens[i].type == JSMN_STRING);
+				assert(tokens[i].end - tokens[i].start > 0);
+				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
+				(*module_config_vec)[module_idx].path = strndup(val, tokens[i].end - tokens[i].start);
+			} else if (strcmp(key, "port") == 0) {
+				assert(tokens[i].size == 1);
+				i++;
+				assert(tokens[i].type == JSMN_PRIMITIVE);
+				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
+				// Validate sane port
+				// If already taken, will error on bind call in module_listen
+				int buffer = atoi(val);
+				if (buffer < 0 || buffer > 65535)
+					panic("Expected port between 0 and 65535, saw %d\n", buffer);
+				(*module_config_vec)[module_idx].port = buffer;
+			} else if (strcmp(key, "expected-execution-us") == 0) {
+				assert(tokens[i].size == 1);
+				i++;
+				assert(tokens[i].type == JSMN_PRIMITIVE);
+				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
+				int64_t buffer = strtoll(val, NULL, 10);
+				if (buffer < 0 || buffer > (int64_t)RUNTIME_EXPECTED_EXECUTION_US_MAX)
+					panic("Relative-deadline-us must be between 0 and %ld, was %ld\n",
+					      (int64_t)RUNTIME_EXPECTED_EXECUTION_US_MAX, buffer);
+				(*module_config_vec)[module_idx].expected_execution_us = (uint32_t)buffer;
+			} else if (strcmp(key, "admissions-percentile") == 0) {
+				assert(tokens[i].size == 1);
+				i++;
+				assert(tokens[i].type == JSMN_PRIMITIVE);
+				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
+				int32_t buffer = strtol(val, NULL, 10);
+				if (buffer > 99 || buffer < 50)
+					panic("admissions-percentile must be > 50 and <= 99 but was %d\n", buffer);
+				(*module_config_vec)[module_idx].admissions_percentile = buffer;
+			} else if (strcmp(key, "relative-deadline-us") == 0) {
+				assert(tokens[i].size == 1);
+				i++;
+				assert(tokens[i].type == JSMN_PRIMITIVE);
+				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
+				int64_t buffer = strtoll(val, NULL, 10);
+				if (buffer < 0 || buffer > (int64_t)RUNTIME_RELATIVE_DEADLINE_US_MAX)
+					panic("Relative-deadline-us must be between 0 and %ld, was %ld\n",
+					      (int64_t)RUNTIME_RELATIVE_DEADLINE_US_MAX, buffer);
+				(*module_config_vec)[module_idx].relative_deadline_us = (uint32_t)buffer;
+			} else if (strcmp(key, "http-req-size") == 0) {
+				assert(tokens[i].size == 1);
+				i++;
+				assert(tokens[i].type == JSMN_PRIMITIVE);
+				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
+				int64_t buffer = strtoll(val, NULL, 10);
+				if (buffer < 0 || buffer > RUNTIME_HTTP_REQUEST_SIZE_MAX)
+					panic("http-req-size must be between 0 and %ld, was %ld\n",
+					      (int64_t)RUNTIME_HTTP_REQUEST_SIZE_MAX, buffer);
+				(*module_config_vec)[module_idx].http_req_size = (int32_t)buffer;
+			} else if (strcmp(key, "http-resp-size") == 0) {
+				assert(tokens[i].size == 1);
+				i++;
+				assert(tokens[i].type == JSMN_PRIMITIVE);
+				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
+				int64_t buffer = strtoll(val, NULL, 10);
+				if (buffer < 0 || buffer > RUNTIME_HTTP_REQUEST_SIZE_MAX)
+					panic("http-req-size must be between 0 and %ld, was %ld\n",
+					      (int64_t)RUNTIME_HTTP_RESPONSE_SIZE_MAX, buffer);
+				(*module_config_vec)[module_idx].http_resp_size = (int32_t)buffer;
+			} else if (strcmp(key, "http-resp-content-type") == 0) {
+				assert(tokens[i].size == 1);
+				i++;
+				assert(tokens[i].type == JSMN_STRING);
+				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
+				(*module_config_vec)[module_idx].http_resp_content_type = strndup(val,
+				                                                                  tokens[i].end
+				                                                                    - tokens[i].start);
+			} else {
+				fprintf(stderr, "%s is not a valid key\n", key);
+				goto json_parse_err;
+			}
+			module_fields_remaining--;
+		}
+	}
+
+#ifdef LOG_MODULE_LOADING
+	debuglog("Loaded %d module%s!\n", module_count, module_count > 1 ? "s" : "");
+#endif
+
+done:
+	return module_config_vec_len;
+json_parse_err:
+	free(*module_config_vec);
+err:
+	module_config_vec_len = -1;
+	goto done;
+}

--- a/runtime/include/json.h
+++ b/runtime/include/json.h
@@ -39,8 +39,8 @@ jsmn_type(jsmntype_t type)
 static inline bool
 has_valid_size(jsmntok_t tok, char *key, int expected_size)
 {
-	if (tok.size != 1) {
-		fprintf(stderr, "%s does not have a value\n", key);
+	if (tok.size != expected_size) {
+		fprintf(stderr, "%s has size %d, expected %d\n", key, tok.size, expected_size);
 		return false;
 	}
 

--- a/runtime/include/json.h
+++ b/runtime/include/json.h
@@ -16,6 +16,30 @@
 
 #define JSON_TOKENS_CAPACITY 16384
 
+enum
+{
+	module_name,
+	module_path,
+	module_port,
+	module_expected_execution_us,
+	module_admissions_percentile,
+	module_relative_deadline_us,
+	module_http_req_size,
+	module_http_resp_size,
+	module_http_resp_content_type,
+	module_keys_len
+};
+
+static const char *module_keys[module_keys_len] = { "name",
+	                                            "path",
+	                                            "port",
+	                                            "expected-execution-us",
+	                                            "admissions-percentile",
+	                                            "relative-deadline-us",
+	                                            "http-req-size",
+	                                            "http-resp-size",
+	                                            "http-resp-content-type" };
+
 static inline char *
 jsmn_type(jsmntype_t type)
 {
@@ -208,53 +232,53 @@ parse_json(const char *json_buf, ssize_t json_buf_size, struct module_config **m
 			/* Advance to Value */
 			i++;
 
-			if (strcmp(key, "name") == 0) {
+			if (strcmp(key, module_keys[module_name]) == 0) {
 				if (!is_nonempty_string(tokens[i], key)) goto json_parse_err;
 
 				(*module_config_vec)[module_idx].name = strndup(json_buf + tokens[i].start,
 				                                                tokens[i].end - tokens[i].start);
-			} else if (strcmp(key, "path") == 0) {
+			} else if (strcmp(key, module_keys[module_path]) == 0) {
 				if (!is_nonempty_string(tokens[i], key)) goto json_parse_err;
 
 				(*module_config_vec)[module_idx].path = strndup(json_buf + tokens[i].start,
 				                                                tokens[i].end - tokens[i].start);
-			} else if (strcmp(key, "port") == 0) {
+			} else if (strcmp(key, module_keys[module_port]) == 0) {
 				if (!has_valid_type(tokens[i], key, JSMN_PRIMITIVE)) goto json_parse_err;
 
-				int rc = parse_uint16_t(tokens[i], json_buf, "port",
+				int rc = parse_uint16_t(tokens[i], json_buf, module_keys[module_port],
 				                        &(*module_config_vec)[module_idx].port);
 				if (rc < 0) goto json_parse_err;
-			} else if (strcmp(key, "expected-execution-us") == 0) {
+			} else if (strcmp(key, module_keys[module_expected_execution_us]) == 0) {
 				if (!has_valid_type(tokens[i], key, JSMN_PRIMITIVE)) goto json_parse_err;
 
-				int rc = parse_uint32_t(tokens[i], json_buf, "expected-execution-us",
+				int rc = parse_uint32_t(tokens[i], json_buf, module_keys[module_expected_execution_us],
 				                        &(*module_config_vec)[module_idx].expected_execution_us);
 				if (rc < 0) goto json_parse_err;
-			} else if (strcmp(key, "admissions-percentile") == 0) {
+			} else if (strcmp(key, module_keys[module_admissions_percentile]) == 0) {
 				if (!has_valid_type(tokens[i], key, JSMN_PRIMITIVE)) goto json_parse_err;
 
-				int rc = parse_uint8_t(tokens[i], json_buf, "admissions-percentile",
+				int rc = parse_uint8_t(tokens[i], json_buf, module_keys[module_admissions_percentile],
 				                       &(*module_config_vec)[module_idx].admissions_percentile);
 				if (rc < 0) goto json_parse_err;
-			} else if (strcmp(key, "relative-deadline-us") == 0) {
+			} else if (strcmp(key, module_keys[module_relative_deadline_us]) == 0) {
 				if (!has_valid_type(tokens[i], key, JSMN_PRIMITIVE)) goto json_parse_err;
 
-				int rc = parse_uint32_t(tokens[i], json_buf, "relative-deadline-us",
+				int rc = parse_uint32_t(tokens[i], json_buf, module_keys[module_relative_deadline_us],
 				                        &(*module_config_vec)[module_idx].relative_deadline_us);
 				if (rc < 0) goto json_parse_err;
-			} else if (strcmp(key, "http-req-size") == 0) {
+			} else if (strcmp(key, module_keys[module_http_req_size]) == 0) {
 				if (!has_valid_type(tokens[i], key, JSMN_PRIMITIVE)) goto json_parse_err;
 
-				int rc = parse_uint32_t(tokens[i], json_buf, "http-req-size",
+				int rc = parse_uint32_t(tokens[i], json_buf, module_keys[module_http_req_size],
 				                        &(*module_config_vec)[module_idx].http_req_size);
 				if (rc < 0) goto json_parse_err;
-			} else if (strcmp(key, "http-resp-size") == 0) {
+			} else if (strcmp(key, module_keys[module_http_resp_size]) == 0) {
 				if (!has_valid_type(tokens[i], key, JSMN_PRIMITIVE)) goto json_parse_err;
 
-				int rc = parse_uint32_t(tokens[i], json_buf, "http-resp-size",
+				int rc = parse_uint32_t(tokens[i], json_buf, module_keys[module_http_resp_size],
 				                        &(*module_config_vec)[module_idx].http_resp_size);
 				if (rc < 0) goto json_parse_err;
-			} else if (strcmp(key, "http-resp-content-type") == 0) {
+			} else if (strcmp(key, module_keys[module_http_resp_content_type]) == 0) {
 				if (!has_valid_type(tokens[i], key, JSMN_STRING)) goto json_parse_err;
 
 				(*module_config_vec)[module_idx].http_resp_content_type =

--- a/runtime/include/json.h
+++ b/runtime/include/json.h
@@ -170,6 +170,8 @@ parse_json(const char *json_buf, ssize_t json_buf_size, struct module_config **m
 		char key[32]  = { 0 };
 		char val[256] = { 0 };
 
+		/* Assumption: Objects are never used within a module_config. This likely will not be true in the
+		 * future due to routes or multiple entrypoints */
 		if (tokens[i].type == JSMN_OBJECT) {
 			assert(module_fields_remaining == 0);
 			module_fields_remaining = tokens[i].size;
@@ -185,20 +187,20 @@ parse_json(const char *json_buf, ssize_t json_buf_size, struct module_config **m
 			/* Validate that key has a value */
 			if (!has_valid_size(tokens[i], key, 1)) goto json_parse_err;
 
+			/* Advance to Value */
+			i++;
+
 			if (strcmp(key, "name") == 0) {
-				i++;
 				if (!is_nonempty_string(tokens[i], key)) goto json_parse_err;
 
 				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
 				(*module_config_vec)[module_idx].name = strndup(val, tokens[i].end - tokens[i].start);
 			} else if (strcmp(key, "path") == 0) {
-				i++;
 				if (!is_nonempty_string(tokens[i], key)) goto json_parse_err;
 
 				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
 				(*module_config_vec)[module_idx].path = strndup(val, tokens[i].end - tokens[i].start);
 			} else if (strcmp(key, "port") == 0) {
-				i++;
 				if (!has_valid_type(tokens[i], key, JSMN_PRIMITIVE)) goto json_parse_err;
 
 				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
@@ -207,7 +209,6 @@ parse_json(const char *json_buf, ssize_t json_buf_size, struct module_config **m
 					panic("Expected port between 0 and 65535, saw %d\n", buffer);
 				(*module_config_vec)[module_idx].port = buffer;
 			} else if (strcmp(key, "expected-execution-us") == 0) {
-				i++;
 				if (!has_valid_type(tokens[i], key, JSMN_PRIMITIVE)) goto json_parse_err;
 
 				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
@@ -217,7 +218,6 @@ parse_json(const char *json_buf, ssize_t json_buf_size, struct module_config **m
 					      (int64_t)RUNTIME_EXPECTED_EXECUTION_US_MAX, buffer);
 				(*module_config_vec)[module_idx].expected_execution_us = (uint32_t)buffer;
 			} else if (strcmp(key, "admissions-percentile") == 0) {
-				i++;
 				if (!has_valid_type(tokens[i], key, JSMN_PRIMITIVE)) goto json_parse_err;
 
 				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
@@ -226,7 +226,6 @@ parse_json(const char *json_buf, ssize_t json_buf_size, struct module_config **m
 					panic("admissions-percentile must be > 50 and <= 99 but was %d\n", buffer);
 				(*module_config_vec)[module_idx].admissions_percentile = buffer;
 			} else if (strcmp(key, "relative-deadline-us") == 0) {
-				i++;
 				if (!has_valid_type(tokens[i], key, JSMN_PRIMITIVE)) goto json_parse_err;
 
 				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
@@ -236,7 +235,6 @@ parse_json(const char *json_buf, ssize_t json_buf_size, struct module_config **m
 					      (int64_t)RUNTIME_RELATIVE_DEADLINE_US_MAX, buffer);
 				(*module_config_vec)[module_idx].relative_deadline_us = (uint32_t)buffer;
 			} else if (strcmp(key, "http-req-size") == 0) {
-				i++;
 				if (!has_valid_type(tokens[i], key, JSMN_PRIMITIVE)) goto json_parse_err;
 
 				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
@@ -246,7 +244,6 @@ parse_json(const char *json_buf, ssize_t json_buf_size, struct module_config **m
 					      (int64_t)RUNTIME_HTTP_REQUEST_SIZE_MAX, buffer);
 				(*module_config_vec)[module_idx].http_req_size = (int32_t)buffer;
 			} else if (strcmp(key, "http-resp-size") == 0) {
-				i++;
 				if (!has_valid_type(tokens[i], key, JSMN_PRIMITIVE)) goto json_parse_err;
 
 				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);
@@ -256,7 +253,6 @@ parse_json(const char *json_buf, ssize_t json_buf_size, struct module_config **m
 					      (int64_t)RUNTIME_HTTP_RESPONSE_SIZE_MAX, buffer);
 				(*module_config_vec)[module_idx].http_resp_size = (int32_t)buffer;
 			} else if (strcmp(key, "http-resp-content-type") == 0) {
-				i++;
 				if (!has_valid_type(tokens[i], key, JSMN_STRING)) goto json_parse_err;
 
 				sprintf(val, "%.*s", tokens[i].end - tokens[i].start, json_buf + tokens[i].start);

--- a/runtime/include/json.h
+++ b/runtime/include/json.h
@@ -12,35 +12,10 @@
 #include "runtime.h"
 #include "http.h"
 #include "module.h"
+#include "module_config.h"
 
 static const int JSON_MAX_ELEMENT_COUNT = 16;
 static const int JSON_MAX_ELEMENT_SIZE  = 1024;
-
-struct module_config {
-	char    *name;
-	char    *path;
-	uint16_t port;
-	uint8_t  admissions_percentile;
-	uint32_t expected_execution_us;
-	uint32_t relative_deadline_us;
-	uint32_t http_req_size;
-	uint32_t http_resp_size;
-	char    *http_resp_content_type;
-};
-
-static void
-print_module_config(struct module_config *config)
-{
-	printf("Name: %s\n", config->name);
-	printf("Path: %s\n", config->path);
-	printf("Port: %u\n", config->port);
-	printf("expected_execution_us: %u\n", config->expected_execution_us);
-	printf("admissions_percentile: %u\n", config->admissions_percentile);
-	printf("relative_deadline_us: %u\n", config->relative_deadline_us);
-	printf("http_req_size: %u\n", config->http_req_size);
-	printf("http_resp_size: %u\n", config->http_resp_size);
-	printf("http_resp_content_type: %s\n", config->http_resp_content_type);
-}
 
 static inline char *
 jsmn_type(jsmntype_t type)

--- a/runtime/include/json.h
+++ b/runtime/include/json.h
@@ -14,7 +14,7 @@
 #include "module.h"
 #include "module_config.h"
 
-#define JSON_TOKENS_CAPACITY 1024
+#define JSON_TOKENS_CAPACITY 16384
 
 static inline char *
 jsmn_type(jsmntype_t type)

--- a/runtime/include/json.h
+++ b/runtime/include/json.h
@@ -14,8 +14,7 @@
 #include "module.h"
 #include "module_config.h"
 
-static const int JSON_MAX_ELEMENT_COUNT = 16;
-static const int JSON_MAX_ELEMENT_SIZE  = 1024;
+#define JSON_TOKENS_CAPACITY 1024
 
 static inline char *
 jsmn_type(jsmntype_t type)
@@ -145,7 +144,7 @@ parse_json(const char *json_buf, ssize_t json_buf_size, struct module_config **m
 	assert(json_buf_size > 0);
 	assert(module_config_vec != NULL);
 
-	jsmntok_t tokens[JSON_MAX_ELEMENT_SIZE * JSON_MAX_ELEMENT_COUNT];
+	jsmntok_t tokens[JSON_TOKENS_CAPACITY];
 	int       module_config_vec_len = 0;
 
 
@@ -154,8 +153,7 @@ parse_json(const char *json_buf, ssize_t json_buf_size, struct module_config **m
 	jsmn_init(&module_parser);
 
 	/* Use Jasmine to parse the JSON */
-	int total_tokens = jsmn_parse(&module_parser, json_buf, json_buf_size, tokens,
-	                              sizeof(tokens) / sizeof(tokens[0]));
+	int total_tokens = jsmn_parse(&module_parser, json_buf, json_buf_size, tokens, JSON_TOKENS_CAPACITY);
 	if (total_tokens < 0) {
 		if (total_tokens == JSMN_ERROR_INVAL) {
 			fprintf(stderr, "Error parsing %s: bad token, JSON string is corrupted\n", json_buf);

--- a/runtime/include/module.h
+++ b/runtime/include/module.h
@@ -57,7 +57,7 @@ struct module {
 	char                   path[MODULE_MAX_PATH_LENGTH];
 	uint32_t               stack_size; /* a specification? */
 	uint32_t               relative_deadline_us;
-	int                    port;
+	uint16_t               port;
 	struct admissions_info admissions_info;
 	uint64_t               relative_deadline; /* cycles */
 
@@ -241,7 +241,7 @@ module_free_linear_memory(struct module *module, struct wasm_memory *memory)
  * Public Methods from module.c *
  *******************************/
 
-void module_free(struct module *module);
-struct module *
-module_alloc(char *mod_name, char *mod_path, uint32_t stack_sz, uint32_t relative_deadline_us, int port, int req_sz,
-             int resp_sz, int admissions_percentile, uint32_t expected_execution_us, char *response_content_type);
+void           module_free(struct module *module);
+struct module *module_alloc(char *name, char *path, uint32_t stack_size, uint32_t relative_deadline_us, uint16_t port,
+                            uint32_t request_size, uint32_t response_size, uint8_t admissions_percentile,
+                            uint32_t expected_execution_us, char *response_content_type);

--- a/runtime/include/module.h
+++ b/runtime/include/module.h
@@ -9,6 +9,7 @@
 #include "admissions_info.h"
 #include "current_wasm_module_instance.h"
 #include "http.h"
+#include "module_config.h"
 #include "panic.h"
 #include "pool.h"
 #include "sledge_abi_symbols.h"
@@ -242,7 +243,5 @@ module_free_linear_memory(struct module *module, struct wasm_memory *memory)
  *******************************/
 
 void           module_free(struct module *module);
-struct module *module_alloc(char *name, char *path, uint32_t stack_size, uint32_t relative_deadline_us, uint16_t port,
-                            uint32_t request_size, uint32_t response_size, uint8_t admissions_percentile,
-                            uint32_t expected_execution_us, char *response_content_type);
+struct module *module_alloc(struct module_config *config);
 int            module_listen(struct module *module);

--- a/runtime/include/module.h
+++ b/runtime/include/module.h
@@ -241,7 +241,7 @@ module_free_linear_memory(struct module *module, struct wasm_memory *memory)
  * Public Methods from module.c *
  *******************************/
 
-void           module_free(struct module *module);
-struct module *module_alloc(char *mod_name, char *mod_path, uint32_t stack_sz, uint32_t relative_deadline_us, int port,
-                            int req_sz, int resp_sz, int admissions_percentile, uint32_t expected_execution_us);
-int            module_alloc_from_json(const char *json_buf, ssize_t json_buf_size);
+void module_free(struct module *module);
+struct module *
+module_alloc(char *mod_name, char *mod_path, uint32_t stack_sz, uint32_t relative_deadline_us, int port, int req_sz,
+             int resp_sz, int admissions_percentile, uint32_t expected_execution_us, char *response_content_type);

--- a/runtime/include/module.h
+++ b/runtime/include/module.h
@@ -244,4 +244,4 @@ module_free_linear_memory(struct module *module, struct wasm_memory *memory)
 void           module_free(struct module *module);
 struct module *module_alloc(char *mod_name, char *mod_path, uint32_t stack_sz, uint32_t relative_deadline_us, int port,
                             int req_sz, int resp_sz, int admissions_percentile, uint32_t expected_execution_us);
-int            module_alloc_from_json(char *filename);
+int            module_alloc_from_json(const char *json_buf, ssize_t json_buf_size);

--- a/runtime/include/module.h
+++ b/runtime/include/module.h
@@ -245,3 +245,4 @@ void           module_free(struct module *module);
 struct module *module_alloc(char *name, char *path, uint32_t stack_size, uint32_t relative_deadline_us, uint16_t port,
                             uint32_t request_size, uint32_t response_size, uint8_t admissions_percentile,
                             uint32_t expected_execution_us, char *response_content_type);
+int            module_listen(struct module *module);

--- a/runtime/include/module_config.h
+++ b/runtime/include/module_config.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+struct module_config {
+	char    *name;
+	char    *path;
+	uint16_t port;
+	uint8_t  admissions_percentile;
+	uint32_t expected_execution_us;
+	uint32_t relative_deadline_us;
+	uint32_t http_req_size;
+	uint32_t http_resp_size;
+	char    *http_resp_content_type;
+};
+
+static inline void
+module_config_free(struct module_config *config)
+{
+	free(config->name);
+	free(config->path);
+	free(config->http_resp_content_type);
+	free(config);
+}
+
+static inline void
+print_module_config(struct module_config *config)
+{
+	printf("Name: %s\n", config->name);
+	printf("Path: %s\n", config->path);
+	printf("Port: %u\n", config->port);
+	printf("admissions_percentile: %u\n", config->admissions_percentile);
+	printf("expected_execution_us: %u\n", config->expected_execution_us);
+	printf("relative_deadline_us: %u\n", config->relative_deadline_us);
+	printf("http_req_size: %u\n", config->http_req_size);
+	printf("http_resp_size: %u\n", config->http_resp_size);
+	printf("http_resp_content_type: %s\n", config->http_resp_content_type);
+}

--- a/runtime/include/module_config.h
+++ b/runtime/include/module_config.h
@@ -17,12 +17,11 @@ struct module_config {
 };
 
 static inline void
-module_config_free(struct module_config *config)
+module_config_deinit(struct module_config *config)
 {
 	free(config->name);
 	free(config->path);
 	free(config->http_resp_content_type);
-	free(config);
 }
 
 static inline void

--- a/runtime/include/module_database.h
+++ b/runtime/include/module_database.h
@@ -7,3 +7,4 @@
 int            module_database_add(struct module *module);
 struct module *module_database_find_by_name(char *name);
 struct module *module_database_find_by_socket_descriptor(int socket_descriptor);
+struct module *module_database_find_by_port(uint16_t port);

--- a/runtime/include/perf_window.h
+++ b/runtime/include/perf_window.h
@@ -145,16 +145,16 @@ done:
  * @returns execution time
  */
 static inline uint64_t
-perf_window_get_percentile(struct perf_window *perf_window, int percentile, int precomputed_index)
+perf_window_get_percentile(struct perf_window *perf_window, uint8_t percentile, int precomputed_index)
 {
 	assert(perf_window != NULL);
 	assert(percentile >= 50 && percentile <= 99);
-	int size = perf_window->count;
-	assert(size > 0);
+	assert(perf_window->count > 0);
 
-	if (likely(size >= PERF_WINDOW_BUFFER_SIZE)) return perf_window->by_duration[precomputed_index].execution_time;
+	if (likely(perf_window->count >= PERF_WINDOW_BUFFER_SIZE))
+		return perf_window->by_duration[precomputed_index].execution_time;
 
-	return perf_window->by_duration[size * percentile / 100].execution_time;
+	return perf_window->by_duration[perf_window->count * percentile / 100].execution_time;
 }
 
 /**

--- a/runtime/src/admissions_info.c
+++ b/runtime/src/admissions_info.c
@@ -6,7 +6,7 @@
  * @param admissions_info
  */
 void
-admissions_info_initialize(struct admissions_info *admissions_info, int percentile, uint64_t expected_execution,
+admissions_info_initialize(struct admissions_info *admissions_info, uint8_t percentile, uint64_t expected_execution,
                            uint64_t relative_deadline)
 {
 #ifdef ADMISSIONS_CONTROL
@@ -24,7 +24,7 @@ admissions_info_initialize(struct admissions_info *admissions_info, int percenti
 
 	admissions_info->control_index = PERF_WINDOW_BUFFER_SIZE * percentile / 100;
 #ifdef LOG_ADMISSIONS_CONTROL
-	debuglog("Percentile: %d\n", admissions_info->percentile);
+	debuglog("Percentile: %u\n", admissions_info->percentile);
 	debuglog("Control Index: %d\n", admissions_info->control_index);
 #endif
 #endif

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -475,6 +475,9 @@ main(int argc, char **argv)
 		                                     module_config_vec[module_idx].expected_execution_us,
 		                                     module_config_vec[module_idx].http_resp_content_type);
 		if (unlikely(module == NULL)) panic("failed to initialize module(s) defined in %s\n", json_path);
+		/* Start listening for requests */
+		int rc = module_listen(module);
+		if (rc < 0) exit(-1);
 	}
 
 	for (int i = 0; i < runtime_worker_threads_count; i++) {

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -394,7 +394,6 @@ load_file_into_buffer(const char *file_name, char **file_buffer)
 		fprintf(stderr, "Attempt to read %s into buffer failed: %s\n", file_name, strerror(errno));
 		goto fread_err;
 	}
-	assert(total_chars_read > 0);
 
 	/* Close the file */
 	if (fclose(module_file) == EOF) {

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -463,6 +463,7 @@ main(int argc, char **argv)
 
 	int module_config_vec_len = parse_json(json_buf, json_buf_len, &module_config_vec);
 	if (module_config_vec_len < 0) { exit(-1); }
+	free(json_buf);
 
 	for (int module_idx = 0; module_idx < module_config_vec_len; module_idx++) {
 		/* Automatically calls listen */

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -461,6 +461,8 @@ main(int argc, char **argv)
 	struct module_config *module_config_vec;
 
 	int module_config_vec_len = parse_json(json_buf, json_buf_len, &module_config_vec);
+	if (module_config_vec_len < 0) { exit(-1); }
+
 	for (int module_idx = 0; module_idx < module_config_vec_len; module_idx++) {
 		/* Automatically calls listen */
 		struct module *module = module_alloc(module_config_vec[module_idx].name,

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -351,7 +351,7 @@ check_versions()
  * Allocates a buffer in memory containing the entire contents of the file provided
  * @param file_name file to load into memory
  * @param ret_ptr Pointer to set with address of buffer this function allocates. The caller must free this!
- * @return size of the allocated buffer or -1 in case of error;
+ * @return size of the allocated buffer or 0 in case of error;
  */
 static inline size_t
 load_file_into_buffer(const char *file_name, char **file_buffer)
@@ -386,7 +386,7 @@ load_file_into_buffer(const char *file_name, char **file_buffer)
 	}
 
 	/* Read the file into the buffer and check that the buffer size equals the file size */
-	ssize_t total_chars_read = fread(*file_buffer, sizeof(char), stat_buffer.st_size, module_file);
+	size_t total_chars_read = fread(*file_buffer, sizeof(char), stat_buffer.st_size, module_file);
 #ifdef LOG_MODULE_LOADING
 	debuglog("size read: %d content: %s\n", total_chars_read, *file_buffer);
 #endif
@@ -414,7 +414,7 @@ stat_buffer_alloc_err:
 		if (fclose(module_file) == EOF) panic("Failed to close file\n");
 	}
 err:
-	return (ssize_t)-1;
+	return 0;
 }
 
 int
@@ -455,8 +455,8 @@ main(int argc, char **argv)
 #endif
 	const char *json_path    = argv[1];
 	char       *json_buf     = NULL;
-	ssize_t     json_buf_len = load_file_into_buffer(json_path, &json_buf);
-	if (unlikely(json_buf_len <= 0)) panic("failed to initialize module(s) defined in %s\n", json_path);
+	size_t      json_buf_len = load_file_into_buffer(json_path, &json_buf);
+	if (unlikely(json_buf_len == 0)) panic("failed to initialize module(s) defined in %s\n", json_path);
 
 	struct module_config *module_config_vec;
 

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -481,8 +481,9 @@ main(int argc, char **argv)
 	}
 
 	for (int module_idx = 0; module_idx < module_config_vec_len; module_idx++) {
-		module_config_free(&module_config_vec[module_idx]);
+		module_config_deinit(&module_config_vec[module_idx]);
 	}
+	free(module_config_vec);
 
 	for (int i = 0; i < runtime_worker_threads_count; i++) {
 		int ret = pthread_join(runtime_worker_threads[i], NULL);

--- a/runtime/src/module.c
+++ b/runtime/src/module.c
@@ -4,7 +4,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 #include "debuglog.h"
@@ -239,113 +238,38 @@ err:
 }
 
 /**
- * Allocates a buffer in memory containing the entire contents of the file provided
- * @param file_name file to load into memory
- * @param ret_ptr Pointer to set with address of buffer this function allocates. The caller must free this!
- * @return size of the allocated buffer or -1 in case of error;
- */
-static inline size_t
-load_file_into_buffer(char *file_name, char **file_buffer)
-{
-	/* Use stat to get file attributes and make sure file is present and not empty */
-	struct stat stat_buffer;
-	if (stat(file_name, &stat_buffer) < 0) {
-		fprintf(stderr, "Attempt to stat %s failed: %s\n", file_name, strerror(errno));
-		goto err;
-	}
-	if (stat_buffer.st_size == 0) {
-		fprintf(stderr, "File %s is unexpectedly empty\n", file_name);
-		goto err;
-	}
-	if (!S_ISREG(stat_buffer.st_mode)) {
-		fprintf(stderr, "File %s is not a regular file\n", file_name);
-		goto err;
-	}
-
-	/* Open the file */
-	FILE *module_file = fopen(file_name, "r");
-	if (!module_file) {
-		fprintf(stderr, "Attempt to open %s failed: %s\n", file_name, strerror(errno));
-		goto err;
-	}
-
-	/* Initialize a Buffer */
-	*file_buffer = calloc(1, stat_buffer.st_size);
-	if (*file_buffer == NULL) {
-		fprintf(stderr, "Attempt to allocate file buffer failed: %s\n", strerror(errno));
-		goto stat_buffer_alloc_err;
-	}
-
-	/* Read the file into the buffer and check that the buffer size equals the file size */
-	ssize_t total_chars_read = fread(*file_buffer, sizeof(char), stat_buffer.st_size, module_file);
-#ifdef LOG_MODULE_LOADING
-	debuglog("size read: %d content: %s\n", total_chars_read, *file_buffer);
-#endif
-	if (total_chars_read != stat_buffer.st_size) {
-		fprintf(stderr, "Attempt to read %s into buffer failed: %s\n", file_name, strerror(errno));
-		goto fread_err;
-	}
-	assert(total_chars_read > 0);
-
-	/* Close the file */
-	if (fclose(module_file) == EOF) {
-		fprintf(stderr, "Attempt to close buffer containing %s failed: %s\n", file_name, strerror(errno));
-		goto fclose_err;
-	};
-	module_file = NULL;
-
-	return total_chars_read;
-
-fclose_err:
-	/* We will retry fclose when we fall through into stat_buffer_alloc_err */
-fread_err:
-	free(*file_buffer);
-stat_buffer_alloc_err:
-	// Check to ensure we haven't already close this
-	if (module_file != NULL) {
-		if (fclose(module_file) == EOF) panic("Failed to close file\n");
-	}
-err:
-	return (ssize_t)-1;
-}
-
-/**
  * Parses a JSON file and allocates one or more new modules
  * @param file_name The path of the JSON file
  * @return RC 0 on Success. -1 on Error
  */
 int
-module_alloc_from_json(char *file_name)
+module_alloc_from_json(const char *json_buf, ssize_t json_buf_size)
 {
-	assert(file_name != NULL);
+	assert(json_buf != NULL);
+	assert(json_buf_size > 0);
 
 	int       return_code = -1;
 	jsmntok_t tokens[JSON_MAX_ELEMENT_SIZE * JSON_MAX_ELEMENT_COUNT];
-
-	/* Load file_name into memory */
-	char   *file_buffer      = NULL;
-	ssize_t total_chars_read = load_file_into_buffer(file_name, &file_buffer);
-	if (total_chars_read <= 0) goto module_alloc_err;
 
 	/* Initialize the Jasmine Parser and an array to hold the tokens */
 	jsmn_parser module_parser;
 	jsmn_init(&module_parser);
 
 	/* Use Jasmine to parse the JSON */
-	int total_tokens = jsmn_parse(&module_parser, file_buffer, total_chars_read, tokens,
+	int total_tokens = jsmn_parse(&module_parser, json_buf, json_buf_size, tokens,
 	                              sizeof(tokens) / sizeof(tokens[0]));
 	if (total_tokens < 0) {
 		if (total_tokens == JSMN_ERROR_INVAL) {
-			fprintf(stderr, "Error parsing %s: bad token, JSON string is corrupted\n", file_name);
+			fprintf(stderr, "Error parsing %s: bad token, JSON string is corrupted\n", json_buf);
 		} else if (total_tokens == JSMN_ERROR_PART) {
 			fprintf(stderr, "Error parsing %s: JSON string is too short, expecting more JSON data\n",
-			        file_name);
+			        json_buf);
 		} else if (total_tokens == JSMN_ERROR_NOMEM) {
 			/*
 			 * According to the README at https://github.com/zserge/jsmn, this is a potentially recoverable
 			 * error. More tokens can be allocated and jsmn_parse can be re-invoked.
 			 */
-			fprintf(stderr, "Error parsing %s: Not enough tokens, JSON string is too large\n", file_name);
+			fprintf(stderr, "Error parsing %s: Not enough tokens, JSON string is too large\n", json_buf);
 		}
 		goto json_parse_err;
 	}
@@ -375,9 +299,8 @@ module_alloc_from_json(char *file_name)
 			char val[256] = { 0 };
 
 			sprintf(val, "%.*s", tokens[j + i + 1].end - tokens[j + i + 1].start,
-			        file_buffer + tokens[j + i + 1].start);
-			sprintf(key, "%.*s", tokens[j + i].end - tokens[j + i].start,
-			        file_buffer + tokens[j + i].start);
+			        json_buf + tokens[j + i + 1].start);
+			sprintf(key, "%.*s", tokens[j + i].end - tokens[j + i].start, json_buf + tokens[j + i].start);
 
 			if (strlen(key) == 0) panic("Unexpected encountered empty key\n");
 			if (strlen(val) == 0) panic("%s field contained empty string\n", key);
@@ -448,20 +371,16 @@ module_alloc_from_json(char *file_name)
 		module_count++;
 	}
 
-	if (module_count == 0) panic("%s contained no active modules\n", file_name);
+	if (module_count == 0) panic("%s contained no active modules\n", json_buf);
 #ifdef LOG_MODULE_LOADING
 	debuglog("Loaded %d module%s!\n", module_count, module_count > 1 ? "s" : "");
 #endif
-	free(file_buffer);
-
 	return_code = 0;
 
 done:
 	return return_code;
 module_alloc_err:
 json_parse_err:
-file_load_err:
-	free(file_buffer);
 err:
 	return_code = -1;
 	goto done;

--- a/runtime/src/module.c
+++ b/runtime/src/module.c
@@ -20,93 +20,6 @@
  * Private Static Inline *
  ************************/
 
-/**
- * Start the module as a server listening at module->port
- * @param module
- * @returns 0 on success, -1 on error
- */
-static inline int
-module_listen(struct module *module)
-{
-	int rc;
-
-	/* Allocate a new TCP/IP socket, setting it to be non-blocking */
-	int socket_descriptor = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-	if (unlikely(socket_descriptor < 0)) goto err_create_socket;
-
-	/* Socket should never have returned on fd 0, 1, or 2 */
-	assert(socket_descriptor != STDIN_FILENO);
-	assert(socket_descriptor != STDOUT_FILENO);
-	assert(socket_descriptor != STDERR_FILENO);
-
-	/* Configure the socket to allow multiple sockets to bind to the same host and port */
-	int optval = 1;
-	rc         = setsockopt(socket_descriptor, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
-	if (unlikely(rc < 0)) goto err_set_socket_option;
-	optval = 1;
-	rc     = setsockopt(socket_descriptor, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
-	if (unlikely(rc < 0)) goto err_set_socket_option;
-
-	/* Bind name [all addresses]:[module->port] to socket */
-	module->socket_descriptor              = socket_descriptor;
-	module->socket_address.sin_family      = AF_INET;
-	module->socket_address.sin_addr.s_addr = htonl(INADDR_ANY);
-	module->socket_address.sin_port        = htons((unsigned short)module->port);
-	rc = bind(socket_descriptor, (struct sockaddr *)&module->socket_address, sizeof(module->socket_address));
-	if (unlikely(rc < 0)) goto err_bind_socket;
-
-	/* Listen to the interface */
-	rc = listen(socket_descriptor, MODULE_MAX_PENDING_CLIENT_REQUESTS);
-	if (unlikely(rc < 0)) goto err_listen;
-
-
-	/* Set the socket descriptor and register with our global epoll instance to monitor for incoming HTTP
-	requests */
-	rc = listener_thread_register_module(module);
-	if (unlikely(rc < 0)) goto err_add_to_epoll;
-
-	rc = 0;
-done:
-	return rc;
-err_add_to_epoll:
-err_listen:
-err_bind_socket:
-	module->socket_descriptor = -1;
-err_set_socket_option:
-	close(socket_descriptor);
-err_create_socket:
-err:
-	debuglog("Socket Error: %s", strerror(errno));
-	rc = -1;
-	goto done;
-}
-
-/***************************************
- * Public Methods
- ***************************************/
-
-/**
- * Module Mega Teardown Function
- * Closes the socket and dynamic library, and then frees the module
- * Returns harmlessly if there are outstanding references
- *
- * TODO: Untested Functionality. Unsure if this will work. Also, what about the module database? Do we
- * need to do any cleanup there? Issue #17
- * @param module - the module to teardown
- */
-void
-module_free(struct module *module)
-{
-	if (module == NULL) return;
-
-	/* Do not free if we still have oustanding references */
-	if (module->reference_count) return;
-
-	close(module->socket_descriptor);
-	sledge_abi_symbols_deinit(&module->abi);
-	free(module);
-}
-
 static inline int
 module_init(struct module *module, char *name, char *path, uint32_t stack_size, uint32_t relative_deadline_us,
             uint16_t port, uint32_t request_size, uint32_t response_size, uint8_t admissions_percentile,
@@ -191,6 +104,93 @@ done:
 err:
 	rc = -1;
 	goto done;
+}
+
+/***************************************
+ * Public Methods
+ ***************************************/
+
+/**
+ * Start the module as a server listening at module->port
+ * @param module
+ * @returns 0 on success, -1 on error
+ */
+int
+module_listen(struct module *module)
+{
+	int rc;
+
+	/* Allocate a new TCP/IP socket, setting it to be non-blocking */
+	int socket_descriptor = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	if (unlikely(socket_descriptor < 0)) goto err_create_socket;
+
+	/* Socket should never have returned on fd 0, 1, or 2 */
+	assert(socket_descriptor != STDIN_FILENO);
+	assert(socket_descriptor != STDOUT_FILENO);
+	assert(socket_descriptor != STDERR_FILENO);
+
+	/* Configure the socket to allow multiple sockets to bind to the same host and port */
+	int optval = 1;
+	rc         = setsockopt(socket_descriptor, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
+	if (unlikely(rc < 0)) goto err_set_socket_option;
+	optval = 1;
+	rc     = setsockopt(socket_descriptor, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+	if (unlikely(rc < 0)) goto err_set_socket_option;
+
+	/* Bind name [all addresses]:[module->port] to socket */
+	module->socket_descriptor              = socket_descriptor;
+	module->socket_address.sin_family      = AF_INET;
+	module->socket_address.sin_addr.s_addr = htonl(INADDR_ANY);
+	module->socket_address.sin_port        = htons((unsigned short)module->port);
+	rc = bind(socket_descriptor, (struct sockaddr *)&module->socket_address, sizeof(module->socket_address));
+	if (unlikely(rc < 0)) goto err_bind_socket;
+
+	/* Listen to the interface */
+	rc = listen(socket_descriptor, MODULE_MAX_PENDING_CLIENT_REQUESTS);
+	if (unlikely(rc < 0)) goto err_listen;
+
+
+	/* Set the socket descriptor and register with our global epoll instance to monitor for incoming HTTP
+	requests */
+	rc = listener_thread_register_module(module);
+	if (unlikely(rc < 0)) goto err_add_to_epoll;
+
+	rc = 0;
+done:
+	return rc;
+err_add_to_epoll:
+err_listen:
+err_bind_socket:
+	module->socket_descriptor = -1;
+err_set_socket_option:
+	close(socket_descriptor);
+err_create_socket:
+err:
+	debuglog("Socket Error: %s", strerror(errno));
+	rc = -1;
+	goto done;
+}
+
+/**
+ * Module Mega Teardown Function
+ * Closes the socket and dynamic library, and then frees the module
+ * Returns harmlessly if there are outstanding references
+ *
+ * TODO: Untested Functionality. Unsure if this will work. Also, what about the module database? Do we
+ * need to do any cleanup there? Issue #17
+ * @param module - the module to teardown
+ */
+void
+module_free(struct module *module)
+{
+	if (module == NULL) return;
+
+	/* Do not free if we still have oustanding references */
+	if (module->reference_count) return;
+
+	close(module->socket_descriptor);
+	sledge_abi_symbols_deinit(&module->abi);
+	free(module);
 }
 
 /**

--- a/runtime/src/module_database.c
+++ b/runtime/src/module_database.c
@@ -64,3 +64,18 @@ module_database_find_by_socket_descriptor(int socket_descriptor)
 	}
 	return NULL;
 }
+
+/**
+ * Given a port, find the associated module
+ * @param port
+ * @return module or NULL if no match found
+ */
+struct module *
+module_database_find_by_port(uint16_t port)
+{
+	for (size_t i = 0; i < module_database_count; i++) {
+		assert(module_database[i]);
+		if (module_database[i]->port == port) return module_database[i];
+	}
+	return NULL;
+}

--- a/tests/TinyEKF/one_iteration/spec.json
+++ b/tests/TinyEKF/one_iteration/spec.json
@@ -1,10 +1,12 @@
-{
-	"name": "ekf",
-	"path": "gps_ekf.wasm.so",
-	"port": 10000,
-	"expected-execution-us": 5000,
-	"relative-deadline-us": 50000,
-	"http-req-size": 1024000,
-	"http-resp-size": 1024000,
-	"http-resp-content-type": "application/octet-stream"
-}
+[
+	{
+		"name": "ekf",
+		"path": "gps_ekf.wasm.so",
+		"port": 10000,
+		"expected-execution-us": 5000,
+		"relative-deadline-us": 50000,
+		"http-req-size": 1024000,
+		"http-resp-size": 1024000,
+		"http-resp-content-type": "application/octet-stream"
+	}
+]

--- a/tests/empty/concurrency/spec.json
+++ b/tests/empty/concurrency/spec.json
@@ -1,11 +1,13 @@
-{
-	"name": "empty",
-	"path": "empty.wasm.so",
-	"port": 10000,
-	"expected-execution-us": 500,
-	"admissions-percentile": 70,
-	"relative-deadline-us": 50000,
-	"http-req-size": 1024,
-	"http-resp-size": 1024,
-	"http-resp-content-type": "text/plain"
-}
+[
+	{
+		"name": "empty",
+		"path": "empty.wasm.so",
+		"port": 10000,
+		"expected-execution-us": 500,
+		"admissions-percentile": 70,
+		"relative-deadline-us": 50000,
+		"http-req-size": 1024,
+		"http-resp-size": 1024,
+		"http-resp-content-type": "text/plain"
+	}
+]

--- a/tests/gocr/fivebyeight/spec.json
+++ b/tests/gocr/fivebyeight/spec.json
@@ -1,10 +1,12 @@
-{
-	"name": "gocr",
-	"path": "gocr.wasm.so",
-	"port": 10000,
-	"expected-execution-us": 5000,
-	"relative-deadline-us": 36000,
-	"http-req-size": 1024000,
-	"http-resp-size": 1024000,
-	"http-resp-content-type": "text/plain"
-}
+[
+	{
+		"name": "gocr",
+		"path": "gocr.wasm.so",
+		"port": 10000,
+		"expected-execution-us": 5000,
+		"relative-deadline-us": 36000,
+		"http-req-size": 1024000,
+		"http-resp-size": 1024000,
+		"http-resp-content-type": "text/plain"
+	}
+]

--- a/tests/gocr/handwriting/spec.json
+++ b/tests/gocr/handwriting/spec.json
@@ -1,10 +1,12 @@
-{
-	"name": "gocr",
-	"path": "gocr.wasm.so",
-	"port": 10000,
-	"expected-execution-us": 5000,
-	"relative-deadline-us": 36000,
-	"http-req-size": 1024000,
-	"http-resp-size": 1024000,
-	"http-resp-content-type": "text/plain"
-}
+[
+	{
+		"name": "gocr",
+		"path": "gocr.wasm.so",
+		"port": 10000,
+		"expected-execution-us": 5000,
+		"relative-deadline-us": 36000,
+		"http-req-size": 1024000,
+		"http-resp-size": 1024000,
+		"http-resp-content-type": "text/plain"
+	}
+]

--- a/tests/gocr/hyde/spec.json
+++ b/tests/gocr/hyde/spec.json
@@ -1,10 +1,12 @@
-{
-	"name": "gocr",
-	"path": "gocr.wasm.so",
-	"port": 10000,
-	"expected-execution-us": 5000,
-	"relative-deadline-us": 360000,
-	"http-req-size": 5335057,
-	"http-resp-size": 5335057,
-	"http-resp-content-type": "text/plain"
-}
+[
+	{
+		"name": "gocr",
+		"path": "gocr.wasm.so",
+		"port": 10000,
+		"expected-execution-us": 5000,
+		"relative-deadline-us": 360000,
+		"http-req-size": 5335057,
+		"http-resp-size": 5335057,
+		"http-resp-content-type": "text/plain"
+	}
+]

--- a/tests/sod/image_resize/test/spec.json
+++ b/tests/sod/image_resize/test/spec.json
@@ -1,10 +1,12 @@
-{
-	"name": "resize",
-	"path": "resize_image.wasm.so",
-	"port": 10000,
-	"expected-execution-us": 5000,
-	"relative-deadline-us": 50000,
-	"http-req-size": 1024000,
-	"http-resp-size": 1024000,
-	"http-resp-content-type": "image/png"
-}
+[
+	{
+		"name": "resize",
+		"path": "resize_image.wasm.so",
+		"port": 10000,
+		"expected-execution-us": 5000,
+		"relative-deadline-us": 50000,
+		"http-req-size": 1024000,
+		"http-resp-size": 1024000,
+		"http-resp-content-type": "image/png"
+	}
+]

--- a/tests/speechtotext/spec.json
+++ b/tests/speechtotext/spec.json
@@ -1,9 +1,11 @@
-{
-	"name": "hello_ps",
-	"path": "hello_ps.wasm.so",
-	"port": 10000,
-	"relative-deadline-us": 50000,
-	"http-req-size": 102400,
-	"http-resp-size": 1048576,
-	"http-resp-content-type": "image/jpeg"
-}
+[
+	{
+		"name": "hello_ps",
+		"path": "hello_ps.wasm.so",
+		"port": 10000,
+		"relative-deadline-us": 50000,
+		"http-req-size": 102400,
+		"http-resp-size": 1048576,
+		"http-resp-content-type": "image/jpeg"
+	}
+]


### PR DESCRIPTION
The reason I said this isn't quite ready for adding the new keys is that I anticipate that a module object will have some keys that contain array of objects. For example, this might be a "exports" array that contains export objects with a "symbol", a "path", and some scheduler logic. We can't do this currently because our parser assumes that we only have flat module objects. I suggest I handle that as a follow-on effort because that parsing logic change might benefit from a more focused review.

The main changes here are that I refactored the huge `module_alloc_from_json` function into several tiers:
- Loading a *.json file into a in-memory buffer 
- JSON parsing of an in-memory buffer
- Module allocation / initialization
- Module Listening

I added a bunch of JSON validation logic and error handling and did a bit of manual testing. Essentially, the runtime logs the error, dumps the JSON text, and then panics on these sorts of errors.

I also brought in the `module_database` code that has been dormant and unused for like two years! 

Some of the dynamic memory allocation is a bit complicated. I suggest that might be a good thing to focus on during the review.