### PR TITLE
fix: dockerfile issues

### DIFF
--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -80,7 +80,7 @@ RUN ./sledge/install_llvm.sh $LLVM_VERSION
 
 # WASI-SDK
 RUN curl -sS -L -O $WASI_SDK_URL && dpkg -i wasi-sdk_12.0_amd64.deb && rm -f wasi-sdk_12.0_amd64.deb
-ENV WASI_SDK=/opt/wasi-sdk
+ENV WASI_SDK_PATH=/opt/wasi-sdk
 
 # Create non-root user and add to sudoers
 ARG USERNAME=dev

--- a/applications/Makefile
+++ b/applications/Makefile
@@ -12,7 +12,7 @@ LDFLAGS=-shared -fPIC -Wl,--export-dynamic,--whole-archive -L../libsledge/dist/ 
 # LDFLAGS=-flto -fvisibility=hidden
 
 dist:
-	mkdir dist
+	mkdir -p dist
 
 .PHONY: all
 all: \

--- a/libsledge/Makefile
+++ b/libsledge/Makefile
@@ -21,7 +21,7 @@ CFLAGS := -fPIC -O3
 all: dist/libsledge.a
 
 dist:
-	mkdir dist
+	mkdir -p dist
 
 dist/%.o: src/%.c dist
 	clang ${CFLAGS} -c ${INCLUDES} -o $@ $<


### PR DESCRIPTION
Resolves #349

Fixed incorrectly names env var. Also changed mkdir commands to not fail if running `make all` without `clean`.