### PR TITLE
remove sending duplicate http response header

### DIFF
--- a/runtime/include/http_session.h
+++ b/runtime/include/http_session.h
@@ -197,8 +197,6 @@ http_session_set_response_header(struct http_session *session, int status_code)
 		rc = fprintf(session->response_header.handle, HTTP_RESPONSE_CONTENT_LENGTH,
 		             session->response_body.size);
 		assert(rc > 0);
-		rc = fputs(HTTP_RESPONSE_200_OK, session->response_header.handle);
-		assert(rc != EOF);
 	}
 
 	rc = fputs(HTTP_RESPONSE_TERMINATOR, session->response_header.handle);


### PR DESCRIPTION
Remove sending the duplicate http response header. This will cause **hey** failed. With **curl**, you will see the duplicate http response header:
```
HTTP/1.1 200 OK
Server: SLEdge
Connection: close
Content-Type: text/plain
Content-Length: 4
HTTP/1.1 200 OK
Server: SLEdge
Connection: close

144
```
Line 185 has already sent the http response header