### PR TITLE
Remove wasm_apps submodule from Sledge repo

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -94,6 +94,9 @@ jobs:
       - name: Compile SLEdge
         run: |
           make runtime
+      - name: Install wasm_apps link
+        run: |
+          make wasm_apps
       # TODO:Cache assets before being copied to ./runtime/bin
       - name: Cache gocr
         uses: actions/cache@v2

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ dkms.conf
 
 runtime/tags
 runtime/bin
+applications/wasm_apps
 applications/tmp/
 applications/**/*.csv
 applications/**/*.txt

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,3 @@
 [submodule "jsmn"]
 	path = runtime/thirdparty/jsmn
 	url = https://github.com/gwsystems/jsmn.git
-[submodule "wasm_apps"]
-	path = applications/wasm_apps
-	url = https://github.com/gwsystems/wasm_apps.git
-	branch = master

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ submodules:
 	git submodule update --init --recursive
 
 .PHONY: install
-install: submodules all
+install: submodules wasm_apps all
 
 # aWsm: the WebAssembly to LLVM bitcode compiler
 .PHONY: awsm
@@ -49,6 +49,10 @@ applications:
 .PHONY: applications.clean
 applications.clean:
 	make -C applications clean
+
+# Instead of having two copies of wasm_apps, just link to the awsm repo's copy
+wasm_apps:
+	ln -sr awsm/applications/wasm_apps/ applications/
 
 # Tests
 .PHONY: test


### PR DESCRIPTION
The same wasm_apps repo was linked as a submodule to both aWsm and Sledge, which causes some redundancy issues in the workspace. 

In this PR I removed the wasm_apps submodule from Sledge and instead use awsm's copy as a symlink.