### PR TITLE
fib errors for test scripts of fibonacci: Sending a http request with…

### DIFF
--- a/tests/fibonacci/bimodal/run.sh
+++ b/tests/fibonacci/bimodal/run.sh
@@ -50,13 +50,13 @@ run_samples() {
 	local -ir PERF_WINDOW_CAPACITY
 
 	printf "Running Samples: "
-	hey -disable-compression -disable-keepalive -disable-redirects -n "$PERF_WINDOW_CAPACITY" -c "$PERF_WINDOW_CAPACITY" -cpus 3 -t 0 -o csv -m GET -d "40\n" "http://${hostname}:10010/fib2" 1> /dev/null 2> /dev/null || {
+	hey -disable-compression -disable-keepalive -disable-redirects -n "$PERF_WINDOW_CAPACITY" -c "$PERF_WINDOW_CAPACITY" -cpus 3 -t 0 -o csv -m POST -d "40\n" "http://${hostname}:10010/fib2" 1> /dev/null 2> /dev/null || {
 		printf "[ERR]\n"
 		panic "fib40 samples failed with $?"
 		return 1
 	}
 
-	hey -disable-compression -disable-keepalive -disable-redirects -n "$PERF_WINDOW_CAPACITY" -c "$PERF_WINDOW_CAPACITY" -cpus 3 -t 0 -o csv -m GET -d "10\n" "http://${hostname}:100010/fib" 1> /dev/null 2> /dev/null || {
+	hey -disable-compression -disable-keepalive -disable-redirects -n "$PERF_WINDOW_CAPACITY" -c "$PERF_WINDOW_CAPACITY" -cpus 3 -t 0 -o csv -m POST -d "10\n" "http://${hostname}:100010/fib" 1> /dev/null 2> /dev/null || {
 		printf "[ERR]\n"
 		panic "fib10 samples failed with $?"
 		return 1
@@ -94,7 +94,7 @@ run_experiments() {
 
 	# Run each separately
 	printf "\tfib40: "
-	hey -disable-compression -disable-keepalive -disable-redirects -z ${duration_sec}s -cpus 4 -c 100 -t 0 -o csv -m GET -d "40\n" "http://$hostname:10010/fib2" > "$results_directory/fib40.csv" 2> /dev/null || {
+	hey -disable-compression -disable-keepalive -disable-redirects -z ${duration_sec}s -cpus 4 -c 100 -t 0 -o csv -m POST -d "40\n" "http://$hostname:10010/fib2" > "$results_directory/fib40.csv" 2> /dev/null || {
 		printf "[ERR]\n"
 		panic "fib40 failed"
 		return 1
@@ -107,7 +107,7 @@ run_experiments() {
 	printf "[OK]\n"
 
 	printf "\tfib10: "
-	hey -disable-compression -disable-keepalive -disable-redirects -z ${duration_sec}s -cpus 4 -c 100 -t 0 -o csv -m GET -d "10\n" "http://$hostname:10010/fib" > "$results_directory/fib10.csv" 2> /dev/null || {
+	hey -disable-compression -disable-keepalive -disable-redirects -z ${duration_sec}s -cpus 4 -c 100 -t 0 -o csv -m POST -d "10\n" "http://$hostname:10010/fib" > "$results_directory/fib10.csv" 2> /dev/null || {
 		printf "[ERR]\n"
 		panic "fib10 failed"
 		return 1
@@ -125,12 +125,12 @@ run_experiments() {
 	local fib40_con_PID
 	local fib10_con_PID
 
-	hey -disable-compression -disable-keepalive -disable-redirects -z $((duration_sec + 2 * offset))s -cpus 2 -c 100 -t 0 -o csv -m GET -d "40\n" "http://${hostname}:10010/fib2" > "$results_directory/fib40_con.csv" 2> /dev/null &
+	hey -disable-compression -disable-keepalive -disable-redirects -z $((duration_sec + 2 * offset))s -cpus 2 -c 100 -t 0 -o csv -m POST -d "40\n" "http://${hostname}:10010/fib2" > "$results_directory/fib40_con.csv" 2> /dev/null &
 	fib40_con_PID="$!"
 
 	sleep $offset
 
-	hey -disable-compression -disable-keepalive -disable-redirects -z "${duration_sec}s" -cpus 2 -c 100 -t 0 -o csv -m GET -d "10\n" "http://${hostname}:10010/fib" > "$results_directory/fib10_con.csv" 2> /dev/null &
+	hey -disable-compression -disable-keepalive -disable-redirects -z "${duration_sec}s" -cpus 2 -c 100 -t 0 -o csv -m POST -d "10\n" "http://${hostname}:10010/fib" > "$results_directory/fib10_con.csv" 2> /dev/null &
 	fib10_con_PID="$!"
 
 	wait -f "$fib10_con_PID" || {

--- a/tests/fibonacci/concurrency/run_hey.sh
+++ b/tests/fibonacci/concurrency/run_hey.sh
@@ -47,7 +47,7 @@ run_experiments() {
 	printf "Running Experiments:\n"
 	for con in "${concurrency[@]}"; do
 		printf "\t%d Concurrency: " "$con"
-		hey -disable-compression -disable-keepalive -disable-redirects -z "$duration_sec"s -n "$iterations" -c "$con" -o csv -m GET -d "30\n" "http://$hostname:10030/fib" > "$results_directory/con$con.csv" 2> /dev/null || {
+		hey -disable-compression -disable-keepalive -disable-redirects -z "$duration_sec"s -n "$iterations" -c "$con" -o csv -m POST -d "30\n" "http://$hostname:10030/fib" > "$results_directory/con$con.csv" 2> /dev/null || {
 			printf "[ERR]\n"
 			panic "experiment failed"
 			return 1


### PR DESCRIPTION
It seems Sledge right now only supports sending a http request with a http body by POST not GET. You can reproduce this by running hey command with `hey -disable-compression -disable-keepalive -disable-redirects -z "${duration_sec}s" -cpus 2 -c 100 -t 0 -o csv -m GET -d "29\n" "http://${hostname}:10010/fib"`, you will find Sledge reply 200 OK but 0 fib result. After replacing GET with POST, sledge can return the right result. 