### PR TITLE
Fix: Change the TLS-model for the libsledge to init-exec

### DIFF
--- a/libsledge/Makefile
+++ b/libsledge/Makefile
@@ -2,7 +2,7 @@ CFILES := src/*.c
 INCLUDES := -Iinclude/
 
 # fPIC = Position Independent Code, necessary for linking to relative addresses.
-CFLAGS := -fPIC -O3 -flto
+CFLAGS := -fPIC -O3 -flto -ftls-model=initial-exec
 
 # Strips out calls to assert() and disables debuglog
 CFLAGS+=-DNDEBUG


### PR DESCRIPTION
Fix the TLS issue where the access to the thread local variables were not inlined in the final .so file, that were causing 3-4x latency.

Adding the linker flag of tls-model=init-exec fixes the issue.