### PR TITLE
Update install_deb.sh

### DIFF
--- a/install_deb.sh
+++ b/install_deb.sh
@@ -2,7 +2,7 @@
 
 LLVM_VERSION=12
 
-ARCH=$(uname -p)
+ARCH=$(uname -m)
 
 if [[ $ARCH = "x86_64" ]]; then
 	SHFMT_URL=https://github.com/mvdan/sh/releases/download/v3.4.3/shfmt_v3.4.3_linux_amd64


### PR DESCRIPTION
When using `./install_deb.sh` on an x86_64 Debian Bullseye system, I get this:

```
11:24:21 › ./install_deb.sh 
This script only supports x86_64 and aarch64
```

This is because `uname -p` is being used to get the CPU architecture

```
11:25 › lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 11 (bullseye)
Release:	11
Codename:	bullseye

11:25 › uname --help
Usage: uname [OPTION]...
Print certain system information.  With no OPTION, same as -s.

  -a, --all                print all information, in the following order,
                             except omit -p and -i if unknown:
  -s, --kernel-name        print the kernel name
  -n, --nodename           print the network node hostname
  -r, --kernel-release     print the kernel release
  -v, --kernel-version     print the kernel version
  -m, --machine            print the machine hardware name
  -p, --processor          print the processor type **(non-portable)**
  -i, --hardware-platform  print the hardware platform (non-portable)
  -o, --operating-system   print the operating system
      --help     display this help and exit
      --version  output version information and exit

GNU coreutils online help: <https://www.gnu.org/software/coreutils/>
Full documentation <https://www.gnu.org/software/coreutils/uname>
or available locally via: info '(coreutils) uname invocation'
11:25 › uname -p
unknown
11:25 › uname -m
x86_64
```

I'm surprised this hasn't been an issue for others... do I have some bizarro configuration? *shrug*