### PR TITLE
Correct resize response content-type to image/jpeg in workload_mix_realworld

### DIFF
--- a/tests/workload_mix_realworld/spec.json
+++ b/tests/workload_mix_realworld/spec.json
@@ -200,7 +200,7 @@
 				"path": "resize_image.wasm.so",
 				"expected-execution-us": 138903,
 				"relative-deadline-us": 208354,
-				"http-resp-content-type": "image/png",
+				"http-resp-content-type": "image/jpeg",
 				"admissions-percentile": 90
 			},
 			{
@@ -208,7 +208,7 @@
 				"path": "resize_image.wasm.so",
 				"expected-execution-us": 138903,
 				"relative-deadline-us": 222245,
-				"http-resp-content-type": "image/png",
+				"http-resp-content-type": "image/jpeg",
 				"admissions-percentile": 90
 			},
 			{
@@ -216,7 +216,7 @@
 				"path": "resize_image.wasm.so",
 				"expected-execution-us": 138903,
 				"relative-deadline-us": 236135,
-				"http-resp-content-type": "image/png",
+				"http-resp-content-type": "image/jpeg",
 				"admissions-percentile": 90
 			},
 			{
@@ -224,7 +224,7 @@
 				"path": "resize_image.wasm.so",
 				"expected-execution-us": 138903,
 				"relative-deadline-us": 250025,
-				"http-resp-content-type": "image/png",
+				"http-resp-content-type": "image/jpeg",
 				"admissions-percentile": 90
 			},
 			{
@@ -232,7 +232,7 @@
 				"path": "resize_image.wasm.so",
 				"expected-execution-us": 138903,
 				"relative-deadline-us": 263916,
-				"http-resp-content-type": "image/png",
+				"http-resp-content-type": "image/jpeg",
 				"admissions-percentile": 90
 			},
 			{
@@ -240,7 +240,7 @@
 				"path": "resize_image.wasm.so",
 				"expected-execution-us": 138903,
 				"relative-deadline-us": 277806,
-				"http-resp-content-type": "image/png",
+				"http-resp-content-type": "image/jpeg",
 				"admissions-percentile": 90
 			}
 		]


### PR DESCRIPTION
## Summary

The resize routes in `tests/workload_mix_realworld/spec.json` declared `"http-resp-content-type": "image/png"`, but `resize_image.wasm.so` actually emits **JPEG** — its `main()` calls `sod_img_save_as_jpeg(rz, NULL, 0)`. This corrects all six resize routes (`resize_1.5`–`resize_2.0`) to `image/jpeg`.

Confirmed against the standalone `tests/sod/image_resize/test`, which already uses `image/jpeg` and whose output matches `expected_result.jpg` byte-for-byte.

This is a metadata-only label fix (the response bytes were always JPEG); it does not change runtime behavior.

## Context

Found while investigating #253 (resize image truncation). That truncation bug no longer reproduces — it was resolved by the auto-growing HTTP buffers in #363 — but the content-type mislabel surfaced during verification and is worth correcting on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
