### PR TITLE
Deepen TCP listen backlog to cut connection-setup tail latency

### DIFF
--- a/runtime/include/tcp_server.h
+++ b/runtime/include/tcp_server.h
@@ -13,19 +13,17 @@
 #include "likely.h"
 
 /*
- * Defines the listen backlog, the queue length for completely established socketeds waiting to be accepted
- * If this value is greater than the value in /proc/sys/net/core/somaxconn (typically 128), then it is silently
- * truncated to this value. See man listen(2) for info
+ * Defines the listen backlog: the queue length for completely established sockets waiting to be accepted.
+ * The kernel silently caps this to /proc/sys/net/core/somaxconn, so requesting more than the host allows is
+ * harmless (it just truncates). We request a large value because a single listener thread accepts every
+ * connection; under a burst of short-lived, non-keep-alive requests a small backlog overflows, the kernel
+ * drops the connection, and the client only retries after the ~1s initial SYN RTO — a sharp ~1s tail-latency
+ * spike. A deeper backlog absorbs the burst and removes that spike.
  *
- * When configuring the number of sockets to handle, the queue length of incomplete sockets defined in
- * /proc/sys/net/ipv4/tcp_max_syn_backlog should also be considered. Optionally, enabling syncookies removes this
- * maximum logical length. See tcp(7) for more info.
+ * The queue length of incomplete (half-open) sockets in /proc/sys/net/ipv4/tcp_max_syn_backlog should also be
+ * considered; enabling syncookies removes that maximum. See listen(2) and tcp(7).
  */
-#define TCP_SERVER_MAX_PENDING_CLIENT_REQUESTS 128
-#if TCP_SERVER_MAX_PENDING_CLIENT_REQUESTS > 128
-#warning \
-  "TCP_SERVER_MAX_PENDING_CLIENT_REQUESTS likely exceeds the value in /proc/sys/net/core/somaxconn and thus may be silently truncated";
-#endif
+#define TCP_SERVER_MAX_PENDING_CLIENT_REQUESTS 4096
 
 /* L4 TCP State */
 struct tcp_server {


### PR DESCRIPTION
## Summary

A single listener thread accepts **every** client connection. Under a burst of short-lived, non-keep-alive requests — exactly what the `concurrency` experiment generates driving the `empty` workload — the 128-entry accept queue overflows, the kernel drops the connection, and the client only retries after the **~1s initial SYN RTO**, producing a sharp ~1s tail-latency spike.

This raises the listen backlog from 128 to 4096. The kernel silently caps it to `/proc/sys/net/core/somaxconn`, so requesting more than the host allows is harmless. The now-redundant compile-time truncation `#warning` is removed and the rationale folded into the comment. Recent Linux raised the default somaxconn to 4096 (kernel 5.4+).

## Verification

`hey` against the `empty` workload, c=200, 50k requests:

| | backlog 128 | backlog 4096 |
|---|---|---|
| p99.9 | 1084 ms | **283 ms** |
| max | 1109 ms | **292 ms** |
| requests >1s | **202** | **0** |

At concurrency 1–100 (the experiment's actual range) the tail was already clean in both cases — this removes the spike that appears once the connection-setup burst exceeds the old backlog.

## Context (#258)

While investigating #258 ("Poor Tail Latency in Concurrency Experiment"), the reported ~20s p100 tail **did not reproduce** on current `master` — across concurrency 1→100, EDF and FIFO, 120k requests, the worst case was ~101ms with zero requests over 1s. The switching/lifecycle bugs that issue suspected (#224, #66) and the unused deque mutex (#219) are already fixed, and the request path was refactored since. The one real, reproducible tail contributor that remained was this connection-setup backlog, fixed here.

A deeper limit — the single listener thread's accept/parse/send throughput — remains as potential future work; this change absorbs connection-setup bursts but does not raise steady-state accept throughput.

Closes #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
