### PR TITLE
Make workload_mix_realworld experiment params env-overridable

### DIFF
--- a/tests/workload_mix_realworld/run.sh
+++ b/tests/workload_mix_realworld/run.sh
@@ -99,11 +99,12 @@ run_experiments() {
 	fi
 
 	# TODO: Check that workload is in spec.json
-	local -ir batch_size=1
+	# Experiment parameters, overridable via environment variables (defaults shown)
+	local -ir batch_size=${BATCH_SIZE:-1}
 	local -i batch_id=0
 	local -i roll=0
-	local -ir total_iterations=10000
-	local -ir worker_max=50
+	local -ir total_iterations=${TOTAL_ITERATIONS:-10000}
+	local -ir worker_max=${WORKER_MAX:-50}
 	local pids
 
 	printf "Running Experiments: "


### PR DESCRIPTION
## Summary

The performance test in `tests/workload_mix_realworld/run.sh` hardcoded its iteration count, batch size, and worker cap, so tuning a run meant editing the script (and producing noise diffs). Bind them from the environment with the existing defaults as fallbacks — the pattern suggested in the issue:

```bash
local -ir batch_size=${BATCH_SIZE:-1}
local -ir total_iterations=${TOTAL_ITERATIONS:-10000}
local -ir worker_max=${WORKER_MAX:-50}
```

(`random_max=32767` is `RAND_MAX`, a constant, so it's left as-is.)

Behavior is unchanged when the variables are unset. Example override:
```sh
WORKER_MAX=8 TOTAL_ITERATIONS=200 BATCH_SIZE=5 ./run.sh ...
```

## Verification

- `bash -n` syntax check passes.
- Default (unset) → `batch_size=1 total_iterations=10000 worker_max=50`; override (`BATCH_SIZE=5 TOTAL_ITERATIONS=200 WORKER_MAX=8`) → `5 / 200 / 8`.
- `shellcheck` 0.8.0: no new warnings on the changed lines.

Closes #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
