### PR TITLE
Remove unused mutex from the deque request scheduler

### DIFF
--- a/runtime/src/global_request_scheduler_deque.c
+++ b/runtime/src/global_request_scheduler_deque.c
@@ -6,12 +6,15 @@
 
 static struct deque_sandbox *global_request_scheduler_deque;
 
-/* TODO: Should this be used???  */
-static pthread_mutex_t global_request_scheduler_deque_mutex = PTHREAD_MUTEX_INITIALIZER;
-
 /**
- * Pushes a sandbox to the global deque
- * @param sandbox_raw
+ * Pushes a sandbox to the global deque.
+ *
+ * No lock is required: this is a work-stealing deque used as a single-producer / multi-consumer queue. Only the
+ * listener thread ever pushes (the "owner" end), while worker threads only ever steal (the lock-free opposite
+ * end, coordinated by a CAS). The owner's other operation, deque_pop, is never used, so the multi-owner case the
+ * deque comments warn about does not arise here.
+ *
+ * @param sandbox
  * @returns pointer to sandbox if added. NULL otherwise
  */
 static struct sandbox *


### PR DESCRIPTION
## Summary

Answers #291 ("Is the request scheduler deque variant missing locking?"): **no** — it is correctly lock-free for how it's used, and the mutex was dead code.

The deque-backed global request scheduler (`SCHEDULER_FIFO`) is a Chase-Lev work-stealing deque whose safe-without-locks contract is: one *owner* thread does `push`/`pop` on the bottom, and many *thieves* do `steal` on the top (coordinated by CAS). The actual usage is a strict subset of that:

- `add` → `deque_push` is called **only** by the listener thread (single producer, `listener_thread.c`).
- `remove` → `deque_steal` is called by worker threads (multiple consumers, lock-free via CAS on `top`).
- `deque_pop` is **never called**, so the multi-owner case the deque's "use locks if multi-threaded" comment warns about does not arise.

Push and steal touch opposite ends; the producer's barrier publishes `wrk[]` before `bottom`, and concurrent steals are resolved by the CAS on `top` (losers retry with `-EAGAIN`). So no lock is needed, and `global_request_scheduler_deque_mutex` (with its `/* TODO: Should this be used??? */`) was never locked anywhere.

This removes the vestigial mutex and replaces the TODO with a comment documenting the single-producer / lock-free-steal model.

## Verification

- Builds clean; `grep` confirms zero remaining references to the mutex.
- FIFO (deque) scheduler serves 20,000/20,000 requests as 200s with no errors — no functional change.

Closes #291. (#219 was the same observation, already closed as a duplicate of #291.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
