### PR TITLE
[Experimental] Alternate signal stack to make sandbox stack overflows recoverable

### DIFF
--- a/runtime/include/software_interrupt.h
+++ b/runtime/include/software_interrupt.h
@@ -92,6 +92,11 @@ software_interrupt_deferred_sigalrm_replay()
  * Exports from software_interrupt.c *
  ************************/
 
+/* Size of each worker's alternate signal stack. The SA_ONSTACK handlers (SIGSEGV, SIGFPE) only siglongjmp out,
+ * so this needs little space; keep it comfortably above MINSIGSTKSZ. */
+#define SOFTWARE_INTERRUPT_ALT_STACK_SIZE (64 * 1024)
+
+void software_interrupt_alt_stack_initialize(void);
 void software_interrupt_arm_timer(void);
 void software_interrupt_cleanup(void);
 void software_interrupt_disarm_timer(void);

--- a/runtime/src/software_interrupt.c
+++ b/runtime/src/software_interrupt.c
@@ -278,6 +278,19 @@ software_interrupt_initialize(void)
 		/* Mask this signal on the listener thread */
 		software_interrupt_mask_signal(signal);
 
+		/* Deliver the synchronous fault signals (SIGSEGV, SIGFPE) on the per-worker alternate signal
+		 * stack registered by software_interrupt_alt_stack_initialize(). A sandbox stack overflow faults
+		 * on the stack's guard page, leaving no room to deliver the signal on the overflowed stack; running
+		 * the handler on the alternate stack keeps that overflow recoverable (the handler siglongjmps back
+		 * to the sandbox entry on a valid part of the stack). The asynchronous preemption signals (SIGALRM,
+		 * SIGUSR1) stay on the normal stack: they context-switch away rather than returning, which does not
+		 * compose with an alternate stack. */
+		if (signal == SIGSEGV || signal == SIGFPE) {
+			signal_action.sa_flags |= SA_ONSTACK;
+		} else {
+			signal_action.sa_flags &= ~SA_ONSTACK;
+		}
+
 		/* But register the handler for this signal for the process */
 		if (sigaction(signal, &signal_action, NULL)) {
 			perror("sigaction");
@@ -286,6 +299,28 @@ software_interrupt_initialize(void)
 	}
 
 	software_interrupt_counts_alloc();
+}
+
+/**
+ * Registers a per-thread alternate signal stack so that handlers flagged SA_ONSTACK (SIGSEGV, SIGFPE) can run
+ * even when the active sandbox stack is exhausted. Must be called by each worker before it unmasks those signals.
+ */
+void
+software_interrupt_alt_stack_initialize(void)
+{
+	stack_t alt_stack = { 0 };
+	alt_stack.ss_flags = 0;
+	alt_stack.ss_size  = SOFTWARE_INTERRUPT_ALT_STACK_SIZE;
+	alt_stack.ss_sp    = malloc(alt_stack.ss_size);
+	if (alt_stack.ss_sp == NULL) {
+		perror("malloc alternate signal stack");
+		exit(1);
+	}
+
+	if (sigaltstack(&alt_stack, NULL) != 0) {
+		perror("sigaltstack");
+		exit(1);
+	}
 }
 
 void

--- a/runtime/src/worker_thread.c
+++ b/runtime/src/worker_thread.c
@@ -62,6 +62,10 @@ worker_thread_main(void *argument)
 		                                                        tenant_timeout_get_priority);
 	}
 
+	/* Register this worker's alternate signal stack before unmasking the fault signals, so a sandbox stack
+	 * overflow (which faults on the stack guard page) can still be delivered and recovered from. */
+	software_interrupt_alt_stack_initialize();
+
 	software_interrupt_unmask_signal(SIGFPE);
 	software_interrupt_unmask_signal(SIGSEGV);
 


### PR DESCRIPTION
> **Draft / Experimental.** The mechanism is validated, but a real in-runtime sandbox overflow has not been exercised end to end (see Verification). Opening for discussion before promoting.

## Problem

Each sandbox runs on its own `mmap`'d native stack with a `PROT_NONE` guard page below it (`wasm_stack.h`). The signal handlers are registered with only `SA_SIGINFO | SA_RESTART` — **no `sigaltstack`**. So when a sandbox overflows its stack and faults on the guard page, there's no room on the exhausted stack to deliver SIGSEGV, and the kernel kills the whole runtime instead of trapping just that sandbox. The recovery machinery already exists (`current_sandbox_start` does `sigsetjmp`; the handler does `current_sandbox_trap` → `siglongjmp` back to a valid part of the stack) — it just can't run because the signal can't be delivered. (Addresses #290.)

## Change

- Each worker registers a per-thread **alternate signal stack** (`sigaltstack`) in `worker_thread_main`, before unmasking the fault signals.
- The synchronous fault signals **SIGSEGV and SIGFPE** are registered `SA_ONSTACK`, so they're delivered on the alt stack even when the sandbox stack is exhausted → the existing `siglongjmp` recovery runs.
- **SIGALRM / SIGUSR1 are intentionally left off the alt stack.** They context-switch away (non-local exit) rather than returning, which doesn't compose with an alternate stack; isolating `SA_ONSTACK` to the fault handlers keeps the preemption path untouched.

3 files, +44 lines.

## Verification

- **Mechanism proof** — a standalone test reproducing the runtime's exact primitives (guard-paged `mmap` stack run via `makecontext`/`swapcontext`, `sigsetjmp` recovery, handler `siglongjmp`): **without** the alt stack the process is killed by SIGSEGV (exit 139); **with** it, the overflow is `RECOVERED` (exit 0).
- **No regression** — normal workload (empty, EDF + preemption, 20,000 requests) → 20,000/20,000 `200`s, runtime alive, no crashes; confirms the alt stack + selective `SA_ONSTACK` doesn't disturb preemption.
- Builds clean.

### Why experimental / not fully verified

A real in-`sledgert` overflow was **not** exercised end to end: no prebuilt module recurses deeply enough to exhaust the 512 KB native stack (per #290 this is hard to trigger — wasm locals live in linear memory, so it needs deep recursion), and building a custom deeply-recursive module goes through the libsledge `.wasm.so` toolchain. The change is sound by composition (the recovery path pre-exists and already handles traps like linear-memory-OOB SIGSEGV → 500; this only adds alt-stack *delivery*, proven by the mechanism test), but I'd want a real overflow test before marking it non-experimental.

Relates to #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
